### PR TITLE
Abstract data fetching layer with DataFetcher interface to support bob backend

### DIFF
--- a/.github/workflows/push-docker-custom.yaml
+++ b/.github/workflows/push-docker-custom.yaml
@@ -3,7 +3,7 @@ name: Deploy prod images to GHCR
 on:
   push:
     branches:
-      - 'fix/tx-status-validation'
+      - 'feature/bob-connector'
 
 jobs:
   push-store-image:
@@ -21,5 +21,5 @@ jobs:
 
       - name: 'Build Inventory Image'
         run: |
-          docker build . --tag ghcr.io/qubic/qubic-archiver-v2:snapshot
-          docker push ghcr.io/qubic/qubic-archiver-v2:snapshot
+          docker build . --tag ghcr.io/qubic/qubic-archiver-v2:bob-connector
+          docker push ghcr.io/qubic/qubic-archiver-v2:bob-connector

--- a/BOB_GAPS.md
+++ b/BOB_GAPS.md
@@ -55,14 +55,10 @@ response.
 **What**: Bob has per-transaction `executed` status from log events, but does NOT
 expose the `MoneyFlew` bit array that the node connector provides.
 
-**Resolution**: Implemented moneyFlew computation from bob's log events. The archiver
-fetches all logs for a tick via `GET /log/{epoch}/{logIdStart}/{logIdEnd}`, groups
-QU_TRANSFER events by transaction hash, and applies the algorithm:
-```
-moneyFlew = (tx.amount == first_event.amount) && (tx.src == first_event.src)
-         && (tx.dst == first_event.dst) && (tx.tick == first_event.tick)
-```
-Only transactions with `amount > 0` are candidates; others default to false.
+**Resolution**: The archiver queries bob's `GET /tx/{hash}` endpoint for each
+transaction in a tick and reads the authoritative `executed` flag, mapping it
+directly to `moneyFlew`. This matches bob's own `computeTxExecutionDetails`
+logic exactly, including edge cases (protocol txs, non-QU_TRANSFER first events).
 
 See: `network/bob/moneyflew.go`
 

--- a/BOB_GAPS.md
+++ b/BOB_GAPS.md
@@ -50,20 +50,21 @@ response.
 
 ---
 
-## 4. Transaction status (moneyFlew)
+## 4. Transaction status (moneyFlew) - RESOLVED
 
 **What**: Bob has per-transaction `executed` status from log events, but does NOT
 expose the `MoneyFlew` bit array that the node connector provides.
 
-**Current behavior**: The archiver returns empty transaction status (all moneyFlew
-bits set to false) when using bob. The `txstatus` validation is effectively skipped.
+**Resolution**: Implemented moneyFlew computation from bob's log events. The archiver
+fetches all logs for a tick via `GET /log/{epoch}/{logIdStart}/{logIdEnd}`, groups
+QU_TRANSFER events by transaction hash, and applies the algorithm:
+```
+moneyFlew = (tx.amount == first_event.amount) && (tx.src == first_event.src)
+         && (tx.dst == first_event.dst) && (tx.tick == first_event.tick)
+```
+Only transactions with `amount > 0` are candidates; others default to false.
 
-**Impact**: Medium. The `moneyFlew` field is used by API consumers to determine if
-a transaction's side effects were executed. Currently all transactions appear as
-"not executed" when using bob.
-
-**Future fix**: Use `qubic_getTransactionReceipt` to fetch per-transaction execution
-status, then reconstruct the MoneyFlew bit array from the `executed` field.
+See: `network/bob/moneyflew.go`
 
 ---
 

--- a/BOB_GAPS.md
+++ b/BOB_GAPS.md
@@ -1,94 +1,136 @@
-# Bob Connector - Missing Features & Simplifications
+# Bob Connector - Validation Gaps & Requests for Bob Maintainers
 
-This document tracks what's missing or simplified when using bob as the data source
-for the archiver, compared to the direct Qubic node connector. These are candidates
-for future sprint work.
-
-## 1. TargetTickVoteSignature (quorum vote score filtering)
-
-**What**: Bob doesn't expose `SystemInfo.TargetTickVoteSignature`.
-
-**Current behavior**: The archiver skips the vote signature score check
-(`skipScoreCheck=true`) when using bob. Cryptographic signature verification
-of individual votes still runs.
-
-**Impact**: Minor. The score check is an optimization/filtering heuristic, not a
-security-critical validation. Bob has already validated the votes.
-
-**Future fix**: Expose `TargetTickVoteSignature` in bob's `/status` or `/tick` endpoint.
+This document tracks what data integrity validations are **skipped or weakened**
+when using bob as the data source, compared to the direct Qubic node connector.
+Each item describes what bob would need to expose to achieve full validation parity.
 
 ---
 
-## 2. ComputorPacketSignature (mid-epoch computor change detection)
+## Critical Missing Functionality
 
-**What**: Bob doesn't expose `SystemInfo.ComputorPacketSignature`.
+### 0. Epoch transition handling
 
-**Current behavior**: The archiver fetches the computor list once per epoch and
-caches it. It does NOT detect mid-epoch computor list changes.
+**What's missing**: The archiver has no way to discover which epochs bob has stored,
+or to know the `endTick` of each epoch for sequential processing.
 
-**Impact**: Low. Computor list changes mid-epoch are rare. If they occur, the
-archiver may validate ticks against stale computor keys until the next epoch.
+**Current behavior**: `GetTickStatus` returns the **current** epoch from bob's `/status`.
+The processor uses `InitialTick` to detect epoch boundaries. During catchup, if the
+archiver is processing epoch 207 but bob reports epoch 209 as current, it will skip
+epoch 208 entirely — jumping from wherever it is to epoch 209's `InitialTick`.
 
-**Future fix**: Expose `ComputorPacketSignature` in bob's status endpoint, OR
-add a computor-change notification mechanism.
+**Impact**: Critical. Epochs get skipped during catchup, resulting in missing data.
+Also, if bob transitions to a new epoch while the archiver is still syncing the
+previous one, the archiver would abandon the old epoch mid-way.
+
+**What bob has today**:
+- `qubic_getEpochInfo(epoch)` — returns `initialTick`, `endTick` for a specific epoch
+  (`initialTick: 0` when the epoch doesn't exist in bob's database)
+- `qubic_getCurrentEpoch` — returns current epoch info
+- NO endpoint to list all available epochs
+
+**Request**:
+- Expose a list of available epochs (e.g. `qubic_getAvailableEpochs` returning `[207, 208, 209]`)
+- Alternatively, the archiver can probe sequentially using `qubic_getEpochInfo(N)` and
+  check for `initialTick > 0`, but a listing endpoint would be more efficient
+
+**Archiver changes needed**: Refactor processor to iterate epochs sequentially using
+`endTick` boundaries, rather than relying solely on the live epoch from `/status`.
 
 ---
 
-## 3. Arbitrator signature on computor list
+## Currently Skipped Validations
 
-**What**: Bob returns computor identities (60-char strings) via `qubic_getComputors`,
-but does NOT return the raw 64-byte arbitrator signature on the computor list.
+### 1. Quorum vote score filtering (TargetTickVoteSignature)
 
-**Current behavior**: The archiver skips arbitrator signature validation for
-bob-sourced computors and marks them as pre-validated (`Validated: true`).
+**What's missing from bob**: `SystemInfo.TargetTickVoteSignature` — a uint32 threshold
+used to filter quorum votes by their signature score.
 
-**Impact**: Low. Bob has already validated the computor list. The arbitrator
-signature is a trust chain verification that's redundant when trusting bob.
+**What we skip**: The score check in `quorum.verifyTickVoteSignature()`. We still
+verify each vote's cryptographic Schnorr signature against the computor's public key,
+but we don't filter by score threshold.
 
-**Future fix**: Expose the raw computor list signature in bob's `qubic_getComputors`
-response.
+**Impact**: Minor. The score check is an optimization/difficulty filter. Cryptographic
+signature verification (which we DO perform) is the security-critical validation.
+
+**Request**: Expose `TargetTickVoteSignature` in bob's `/status` or `GET /tick/{tick}`
+response, or as a field in `qubic_syncing`.
 
 ---
 
-## 4. Transaction status (moneyFlew) - RESOLVED
+### 2. Mid-epoch computor list change detection (ComputorPacketSignature)
 
-**What**: Bob has per-transaction `executed` status from log events, but does NOT
-expose the `MoneyFlew` bit array that the node connector provides.
+**What's missing from bob**: `SystemInfo.ComputorPacketSignature` — a uint64 that
+changes when the computor list is updated mid-epoch.
 
-**Resolution**: The archiver queries bob's `GET /tx/{hash}` endpoint for each
-transaction in a tick and reads the authoritative `executed` flag, mapping it
-directly to `moneyFlew`. This matches bob's own `computeTxExecutionDetails`
-logic exactly, including edge cases (protocol txs, non-QU_TRANSFER first events).
+**What we skip**: The archiver fetches the computor list once at epoch start and
+reuses it for the entire epoch. It does NOT detect mid-epoch computor list changes.
+
+**Impact**: Low. If computors change mid-epoch, the archiver may validate quorum
+vote signatures against stale public keys. This could cause valid ticks to fail
+validation or (worse) accept votes signed by former computors.
+
+**Request**: Expose `ComputorPacketSignature` in bob's status endpoint. Alternatively,
+expose a computor-list-version or change-tick so the archiver can detect when to refetch.
+
+---
+
+### 3. Arbitrator signature on computor list
+
+**What's missing from bob**: The raw 64-byte arbitrator signature on the computor
+list. Bob's `qubic_getComputors` returns only identity strings (60-char), not the
+signed computor packet.
+
+**What we skip**: Arbitrator signature validation (`computors.Validate()`). The
+archiver trusts bob's computor list and marks it as pre-validated.
+
+**Impact**: Medium. The arbitrator signature proves the computor list was authorized
+by the network arbitrator. Without it, a compromised bob could serve a fake computor
+list, which would then be used to validate quorum votes — effectively bypassing all
+validation.
+
+**Request**: Expose the raw computor list signature (64 bytes, hex-encoded) in the
+`qubic_getComputors` response. This is the `Signature` field from the `Computors`
+struct in the Qubic protocol.
+
+---
+
+### 4. TargetTickVoteSignature storage per epoch
+
+**What's missing from bob**: Same as item #1 (`TargetTickVoteSignature`).
+
+**What we skip**: The archiver does not store `TargetTickVoteSignature` history
+per epoch (`quorum.StoreTargetTickVoteSignature` is skipped). This data is used
+by the archiver API but is non-critical for processing.
+
+**Request**: Same as item #1.
+
+---
+
+## Resolved Items
+
+### Transaction status (moneyFlew) — RESOLVED in bob 1.4.0
+
+Bob 1.4.0 added the `executed` field (tri-state: `true`/`false`/`null`) to each
+transaction in the `qubic_getTickByNumber` response. The archiver reads this directly
+from the RPC call already made in `GetTickTransactions` — zero extra HTTP calls.
 
 See: `network/bob/moneyflew.go`
 
 ---
 
-## 5. Transaction fetching efficiency
+### Transaction fetching (signatures) — RESOLVED
 
-**What**: Bob's `GET /tick/{tick}` returns transaction digests but not full transaction
-bodies. The archiver must make an additional RPC call (`qubic_getTickByNumber` with
-`includeTransactions=true`) to get full transactions with signatures.
-
-**Impact**: Performance. Two HTTP calls per tick instead of one.
-
-**Future fix**: Add full transaction bodies (with signatures) to the REST
-`GET /tick/{tick}` response, or add a query parameter to include them.
+Bob's `qubic_getTickByNumber` with `includeTransactions=true` returns full transaction
+data including signatures. Two HTTP calls per tick (REST for votes/tick data, RPC for
+transactions with signatures) but functionally complete.
 
 ---
 
-## 6. SystemInfo.InitialTick in GetSystemMetadata
+## Summary: What Bob Maintainers Need to Add
 
-**What**: `GetSystemMetadata` for bob currently returns `InitialTick: 0`. The
-`InitialTick` is instead obtained from `GetTickStatus` which reads `/status`.
-
-**Current behavior**: The validator gets `InitialTick` from `GetTickStatus` and
-passes it to computor validation. However, `GetSystemMetadata` returns 0 for
-`InitialTick` which means the computor's initial `TickNumber` will be set to 0
-on first fetch.
-
-**Impact**: Very low. The computor TickNumber is metadata only, not used in
-validation logic.
-
-**Future fix**: Populate `InitialTick` from the cached status response in
-`GetSystemMetadata`.
+| Priority | Field | Where to expose | Purpose |
+|----------|-------|-----------------|---------|
+| **High** | Available epochs list | New `qubic_getAvailableEpochs` endpoint | Sequential epoch processing during catchup |
+| **High** | Computor list signature (64 bytes) | `qubic_getComputors` response | Arbitrator trust chain validation |
+| Medium | `ComputorPacketSignature` (uint64) | `/status` or `qubic_syncing` | Detect mid-epoch computor changes |
+| Low | `TargetTickVoteSignature` (uint32) | `/status` or `GET /tick/{tick}` | Vote score filtering + storage |

--- a/BOB_GAPS.md
+++ b/BOB_GAPS.md
@@ -1,0 +1,97 @@
+# Bob Connector - Missing Features & Simplifications
+
+This document tracks what's missing or simplified when using bob as the data source
+for the archiver, compared to the direct Qubic node connector. These are candidates
+for future sprint work.
+
+## 1. TargetTickVoteSignature (quorum vote score filtering)
+
+**What**: Bob doesn't expose `SystemInfo.TargetTickVoteSignature`.
+
+**Current behavior**: The archiver skips the vote signature score check
+(`skipScoreCheck=true`) when using bob. Cryptographic signature verification
+of individual votes still runs.
+
+**Impact**: Minor. The score check is an optimization/filtering heuristic, not a
+security-critical validation. Bob has already validated the votes.
+
+**Future fix**: Expose `TargetTickVoteSignature` in bob's `/status` or `/tick` endpoint.
+
+---
+
+## 2. ComputorPacketSignature (mid-epoch computor change detection)
+
+**What**: Bob doesn't expose `SystemInfo.ComputorPacketSignature`.
+
+**Current behavior**: The archiver fetches the computor list once per epoch and
+caches it. It does NOT detect mid-epoch computor list changes.
+
+**Impact**: Low. Computor list changes mid-epoch are rare. If they occur, the
+archiver may validate ticks against stale computor keys until the next epoch.
+
+**Future fix**: Expose `ComputorPacketSignature` in bob's status endpoint, OR
+add a computor-change notification mechanism.
+
+---
+
+## 3. Arbitrator signature on computor list
+
+**What**: Bob returns computor identities (60-char strings) via `qubic_getComputors`,
+but does NOT return the raw 64-byte arbitrator signature on the computor list.
+
+**Current behavior**: The archiver skips arbitrator signature validation for
+bob-sourced computors and marks them as pre-validated (`Validated: true`).
+
+**Impact**: Low. Bob has already validated the computor list. The arbitrator
+signature is a trust chain verification that's redundant when trusting bob.
+
+**Future fix**: Expose the raw computor list signature in bob's `qubic_getComputors`
+response.
+
+---
+
+## 4. Transaction status (moneyFlew)
+
+**What**: Bob has per-transaction `executed` status from log events, but does NOT
+expose the `MoneyFlew` bit array that the node connector provides.
+
+**Current behavior**: The archiver returns empty transaction status (all moneyFlew
+bits set to false) when using bob. The `txstatus` validation is effectively skipped.
+
+**Impact**: Medium. The `moneyFlew` field is used by API consumers to determine if
+a transaction's side effects were executed. Currently all transactions appear as
+"not executed" when using bob.
+
+**Future fix**: Use `qubic_getTransactionReceipt` to fetch per-transaction execution
+status, then reconstruct the MoneyFlew bit array from the `executed` field.
+
+---
+
+## 5. Transaction fetching efficiency
+
+**What**: Bob's `GET /tick/{tick}` returns transaction digests but not full transaction
+bodies. The archiver must make an additional RPC call (`qubic_getTickByNumber` with
+`includeTransactions=true`) to get full transactions with signatures.
+
+**Impact**: Performance. Two HTTP calls per tick instead of one.
+
+**Future fix**: Add full transaction bodies (with signatures) to the REST
+`GET /tick/{tick}` response, or add a query parameter to include them.
+
+---
+
+## 6. SystemInfo.InitialTick in GetSystemMetadata
+
+**What**: `GetSystemMetadata` for bob currently returns `InitialTick: 0`. The
+`InitialTick` is instead obtained from `GetTickStatus` which reads `/status`.
+
+**Current behavior**: The validator gets `InitialTick` from `GetTickStatus` and
+passes it to computor validation. However, `GetSystemMetadata` returns 0 for
+`InitialTick` which means the computor's initial `TickNumber` will be set to 0
+on first fetch.
+
+**Impact**: Very low. The computor TickNumber is metadata only, not used in
+validation logic.
+
+**Future fix**: Populate `InitialTick` from the cached status response in
+`GetSystemMetadata`.

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/qubic/go-archiver-v2/db"
 	metrics "github.com/qubic/go-archiver-v2/metrics"
 	"github.com/qubic/go-archiver-v2/network"
+	"github.com/qubic/go-archiver-v2/network/bob"
 	"github.com/qubic/go-archiver-v2/processor"
 	"github.com/qubic/go-archiver-v2/protobuf"
 	"github.com/qubic/go-archiver-v2/validator"
@@ -70,6 +71,10 @@ func run() error {
 		Metrics struct {
 			Namespace string `conf:"default:qubic_archiver_v2"`
 		}
+		Backend struct {
+			Type   string `conf:"default:node"` // "node" or "bob"
+			BobURL string `conf:"default:http://127.0.0.1:40420"`
+		}
 	}
 
 	help, err := conf.Parse(prefix, &cfg)
@@ -115,17 +120,34 @@ func run() error {
 	}
 	defer dbPool.Close()
 
-	clientPool, err := network.NewNodeConnectorPool(qubic.PoolConfig{
-		InitialCap:         cfg.Pool.InitialCap,
-		MaxCap:             cfg.Pool.MaxCap,
-		MaxIdle:            cfg.Pool.MaxIdle,
-		IdleTimeout:        cfg.Pool.IdleTimeout,
-		NodeFetcherUrl:     cfg.Pool.NodeFetcherUrl,
-		NodeFetcherTimeout: cfg.Pool.NodeFetcherTimeout,
-		NodePort:           cfg.Pool.NodePort,
-	})
-	if err != nil {
-		return fmt.Errorf("creating node pool: %w", err)
+	// create data fetcher factory based on backend type
+	var fetcherFactory func() (network.DataFetcher, error)
+
+	switch cfg.Backend.Type {
+	case "node":
+		clientPool, err := network.NewNodeConnectorPool(qubic.PoolConfig{
+			InitialCap:         cfg.Pool.InitialCap,
+			MaxCap:             cfg.Pool.MaxCap,
+			MaxIdle:            cfg.Pool.MaxIdle,
+			IdleTimeout:        cfg.Pool.IdleTimeout,
+			NodeFetcherUrl:     cfg.Pool.NodeFetcherUrl,
+			NodeFetcherTimeout: cfg.Pool.NodeFetcherTimeout,
+			NodePort:           cfg.Pool.NodePort,
+		})
+		if err != nil {
+			return fmt.Errorf("creating node pool: %w", err)
+		}
+		fetcherFactory = func() (network.DataFetcher, error) {
+			return network.NewNodeDataFetcher(clientPool)
+		}
+	case "bob":
+		bobFetcher := bob.NewBobDataFetcher(cfg.Backend.BobURL)
+		fetcherFactory = func() (network.DataFetcher, error) {
+			return bobFetcher, nil
+		}
+		log.Printf("main: Using bob backend at [%s]", cfg.Backend.BobURL)
+	default:
+		return fmt.Errorf("unknown backend type: %s", cfg.Backend.Type)
 	}
 
 	// start processor
@@ -135,7 +157,7 @@ func run() error {
 		return fmt.Errorf("calculating arbitrator public key from [%s]: %w", cfg.Qubic.ArbitratorIdentity, err)
 	}
 	tickValidator := validator.NewValidator(arbitratorPubKey, cfg.Qubic.EnableTxStatusAddon)
-	proc := processor.NewProcessor(clientPool, dbPool, tickValidator, processor.Config{
+	proc := processor.NewProcessor(fetcherFactory, dbPool, tickValidator, processor.Config{
 		ProcessTickTimeout: cfg.Qubic.ProcessTickTimeout,
 	}, m)
 

--- a/network/bob/client.go
+++ b/network/bob/client.go
@@ -1,0 +1,118 @@
+package bob
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client is an HTTP client for bob's REST and JSON-RPC 2.0 API.
+type Client struct {
+	baseURL    string
+	httpClient *http.Client
+}
+
+// NewClient creates a new bob HTTP client.
+func NewClient(baseURL string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+type jsonRPCRequest struct {
+	JSONRPC string      `json:"jsonrpc"`
+	Method  string      `json:"method"`
+	Params  interface{} `json:"params"`
+	ID      int         `json:"id"`
+}
+
+type jsonRPCResponse struct {
+	JSONRPC string          `json:"jsonrpc"`
+	Result  json.RawMessage `json:"result"`
+	Error   *jsonRPCError   `json:"error,omitempty"`
+	ID      int             `json:"id"`
+}
+
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func (e *jsonRPCError) Error() string {
+	return fmt.Sprintf("RPC error %d: %s", e.Code, e.Message)
+}
+
+// RPCCall makes a JSON-RPC 2.0 call to bob.
+func (c *Client) RPCCall(ctx context.Context, method string, params interface{}) (json.RawMessage, error) {
+	reqBody := jsonRPCRequest{
+		JSONRPC: "2.0",
+		Method:  method,
+		Params:  params,
+		ID:      1,
+	}
+
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("marshalling RPC request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/qubic", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("creating RPC request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing RPC request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading RPC response: %w", err)
+	}
+
+	var rpcResp jsonRPCResponse
+	if err := json.Unmarshal(respBody, &rpcResp); err != nil {
+		return nil, fmt.Errorf("unmarshalling RPC response: %w", err)
+	}
+
+	if rpcResp.Error != nil {
+		return nil, rpcResp.Error
+	}
+
+	return rpcResp.Result, nil
+}
+
+// RESTGet makes a GET request to a bob REST endpoint.
+func (c *Client) RESTGet(ctx context.Context, path string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.baseURL+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating REST request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing REST request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading REST response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("REST request failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}

--- a/network/bob/convert.go
+++ b/network/bob/convert.go
@@ -3,9 +3,15 @@ package bob
 import (
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/qubic/go-node-connector/types"
 )
+
+// stripHexPrefix removes a "0x" or "0X" prefix if present.
+func stripHexPrefix(s string) string {
+	return strings.TrimPrefix(strings.TrimPrefix(s, "0x"), "0X")
+}
 
 // qubicHashToBytes32 converts a Qubic hash (60-char lowercase identity encoding)
 // to a [32]byte public key.
@@ -34,13 +40,13 @@ func identityToBytes32(identity string) ([32]byte, error) {
 	return pubKey, nil
 }
 
-// hexToBytes32 converts a hex-encoded string to [32]byte.
+// hexToBytes32 converts a hex-encoded string (with optional 0x prefix) to [32]byte.
 func hexToBytes32(hexStr string) ([32]byte, error) {
 	var result [32]byte
 	if len(hexStr) == 0 {
 		return result, nil
 	}
-	decoded, err := hex.DecodeString(hexStr)
+	decoded, err := hex.DecodeString(stripHexPrefix(hexStr))
 	if err != nil {
 		return result, fmt.Errorf("decoding hex: %w", err)
 	}
@@ -51,13 +57,13 @@ func hexToBytes32(hexStr string) ([32]byte, error) {
 	return result, nil
 }
 
-// hexToBytes64 converts a hex-encoded string to [64]byte (for signatures).
+// hexToBytes64 converts a hex-encoded string (with optional 0x prefix) to [64]byte (for signatures).
 func hexToBytes64(hexStr string) ([64]byte, error) {
 	var result [64]byte
 	if len(hexStr) == 0 {
 		return result, nil
 	}
-	decoded, err := hex.DecodeString(hexStr)
+	decoded, err := hex.DecodeString(stripHexPrefix(hexStr))
 	if err != nil {
 		return result, fmt.Errorf("decoding hex: %w", err)
 	}
@@ -68,12 +74,12 @@ func hexToBytes64(hexStr string) ([64]byte, error) {
 	return result, nil
 }
 
-// hexToBytes converts a hex-encoded string to a byte slice.
+// hexToBytes converts a hex-encoded string (with optional 0x prefix) to a byte slice.
 func hexToBytes(hexStr string) ([]byte, error) {
 	if len(hexStr) == 0 {
 		return nil, nil
 	}
-	return hex.DecodeString(hexStr)
+	return hex.DecodeString(stripHexPrefix(hexStr))
 }
 
 // convertVote converts a bob vote JSON to types.QuorumTickVote.

--- a/network/bob/convert.go
+++ b/network/bob/convert.go
@@ -1,0 +1,246 @@
+package bob
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/qubic/go-node-connector/types"
+)
+
+// qubicHashToBytes32 converts a Qubic hash (60-char lowercase identity encoding)
+// to a [32]byte public key.
+func qubicHashToBytes32(qubicHash string) ([32]byte, error) {
+	if len(qubicHash) == 0 {
+		return [32]byte{}, nil
+	}
+	id := types.Identity(qubicHash)
+	pubKey, err := id.ToPubKey(true) // true = lowercase
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("converting qubic hash %q to bytes: %w", qubicHash, err)
+	}
+	return pubKey, nil
+}
+
+// identityToBytes32 converts a Qubic identity (60-char uppercase) to [32]byte.
+func identityToBytes32(identity string) ([32]byte, error) {
+	if len(identity) == 0 {
+		return [32]byte{}, nil
+	}
+	id := types.Identity(identity)
+	pubKey, err := id.ToPubKey(false) // false = uppercase
+	if err != nil {
+		return [32]byte{}, fmt.Errorf("converting identity %q to bytes: %w", identity, err)
+	}
+	return pubKey, nil
+}
+
+// hexToBytes32 converts a hex-encoded string to [32]byte.
+func hexToBytes32(hexStr string) ([32]byte, error) {
+	var result [32]byte
+	if len(hexStr) == 0 {
+		return result, nil
+	}
+	decoded, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return result, fmt.Errorf("decoding hex: %w", err)
+	}
+	if len(decoded) != 32 {
+		return result, fmt.Errorf("expected 32 bytes, got %d", len(decoded))
+	}
+	copy(result[:], decoded)
+	return result, nil
+}
+
+// hexToBytes64 converts a hex-encoded string to [64]byte (for signatures).
+func hexToBytes64(hexStr string) ([64]byte, error) {
+	var result [64]byte
+	if len(hexStr) == 0 {
+		return result, nil
+	}
+	decoded, err := hex.DecodeString(hexStr)
+	if err != nil {
+		return result, fmt.Errorf("decoding hex: %w", err)
+	}
+	if len(decoded) != 64 {
+		return result, fmt.Errorf("expected 64 bytes, got %d", len(decoded))
+	}
+	copy(result[:], decoded)
+	return result, nil
+}
+
+// hexToBytes converts a hex-encoded string to a byte slice.
+func hexToBytes(hexStr string) ([]byte, error) {
+	if len(hexStr) == 0 {
+		return nil, nil
+	}
+	return hex.DecodeString(hexStr)
+}
+
+// convertVote converts a bob vote JSON to types.QuorumTickVote.
+func convertVote(v bobVote) (types.QuorumTickVote, error) {
+	prevSpectrumDigest, err := qubicHashToBytes32(v.PrevSpectrumDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("prevSpectrumDigest: %w", err)
+	}
+	prevUniverseDigest, err := qubicHashToBytes32(v.PrevUniverseDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("prevUniverseDigest: %w", err)
+	}
+	prevComputerDigest, err := qubicHashToBytes32(v.PrevComputerDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("prevComputerDigest: %w", err)
+	}
+	saltedSpectrumDigest, err := qubicHashToBytes32(v.SaltedSpectrumDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("saltedSpectrumDigest: %w", err)
+	}
+	saltedUniverseDigest, err := qubicHashToBytes32(v.SaltedUniverseDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("saltedUniverseDigest: %w", err)
+	}
+	saltedComputerDigest, err := qubicHashToBytes32(v.SaltedComputerDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("saltedComputerDigest: %w", err)
+	}
+	txDigest, err := qubicHashToBytes32(v.TransactionDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("transactionDigest: %w", err)
+	}
+	expectedNextTickTxDigest, err := qubicHashToBytes32(v.ExpectedNextTickTransactionDigest)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("expectedNextTickTransactionDigest: %w", err)
+	}
+	signature, err := hexToBytes64(v.Signature)
+	if err != nil {
+		return types.QuorumTickVote{}, fmt.Errorf("signature: %w", err)
+	}
+
+	return types.QuorumTickVote{
+		ComputorIndex:                 v.ComputorIndex,
+		Epoch:                         v.Epoch,
+		Tick:                          v.Tick,
+		Millisecond:                   v.Millisecond,
+		Second:                        v.Second,
+		Minute:                        v.Minute,
+		Hour:                          v.Hour,
+		Day:                           v.Day,
+		Month:                         v.Month,
+		Year:                          v.Year,
+		PreviousResourceTestingDigest: v.PrevResourceTestingDigest,
+		SaltedResourceTestingDigest:   v.SaltedResourceTestingDigest,
+		PreviousTransactionBodyDigest: v.PrevTransactionBodyDigest,
+		SaltedTransactionBodyDigest:   v.SaltedTransactionBodyDigest,
+		PreviousSpectrumDigest:        prevSpectrumDigest,
+		PreviousUniverseDigest:        prevUniverseDigest,
+		PreviousComputerDigest:        prevComputerDigest,
+		SaltedSpectrumDigest:          saltedSpectrumDigest,
+		SaltedUniverseDigest:          saltedUniverseDigest,
+		SaltedComputerDigest:          saltedComputerDigest,
+		TxDigest:                      txDigest,
+		ExpectedNextTickTxDigest:      expectedNextTickTxDigest,
+		Signature:                     signature,
+	}, nil
+}
+
+// convertTickData converts bob tick data JSON to types.TickData.
+func convertTickData(td bobTickData) (types.TickData, error) {
+	timelock, err := qubicHashToBytes32(td.Timelock)
+	if err != nil {
+		return types.TickData{}, fmt.Errorf("timelock: %w", err)
+	}
+
+	var transactionDigests [types.NumberOfTransactionsPerTick][32]byte
+	for i, digest := range td.TransactionDigests {
+		if i >= types.NumberOfTransactionsPerTick {
+			break
+		}
+		d, err := qubicHashToBytes32(digest)
+		if err != nil {
+			return types.TickData{}, fmt.Errorf("transactionDigest[%d]: %w", i, err)
+		}
+		transactionDigests[i] = d
+	}
+
+	var contractFees [1024]int64
+	for i, fee := range td.ContractFees {
+		if i >= 1024 {
+			break
+		}
+		contractFees[i] = fee
+	}
+
+	signature, err := hexToBytes64(td.Signature)
+	if err != nil {
+		return types.TickData{}, fmt.Errorf("signature: %w", err)
+	}
+
+	return types.TickData{
+		ComputorIndex:      td.ComputorIndex,
+		Epoch:              td.Epoch,
+		Tick:               td.Tick,
+		Millisecond:        td.Millisecond,
+		Second:             td.Second,
+		Minute:             td.Minute,
+		Hour:               td.Hour,
+		Day:                td.Day,
+		Month:              td.Month,
+		Year:               td.Year,
+		Timelock:           timelock,
+		TransactionDigests: transactionDigests,
+		ContractFees:       contractFees,
+		Signature:          signature,
+	}, nil
+}
+
+// convertRPCTransaction converts a bob RPC transaction to types.Transaction.
+func convertRPCTransaction(tx bobRPCTransaction) (types.Transaction, error) {
+	sourcePubKey, err := identityToBytes32(tx.From)
+	if err != nil {
+		return types.Transaction{}, fmt.Errorf("source identity: %w", err)
+	}
+	destPubKey, err := identityToBytes32(tx.To)
+	if err != nil {
+		return types.Transaction{}, fmt.Errorf("dest identity: %w", err)
+	}
+	signature, err := hexToBytes64(tx.Signature)
+	if err != nil {
+		return types.Transaction{}, fmt.Errorf("signature: %w", err)
+	}
+	input, err := hexToBytes(tx.InputData)
+	if err != nil {
+		return types.Transaction{}, fmt.Errorf("input data: %w", err)
+	}
+
+	return types.Transaction{
+		SourcePublicKey:      sourcePubKey,
+		DestinationPublicKey: destPubKey,
+		Amount:               tx.Amount,
+		Tick:                 0, // tick is not in the per-tx object from qubic_getTickByNumber
+		InputType:            tx.InputType,
+		InputSize:            tx.InputSize,
+		Input:                input,
+		Signature:            signature,
+	}, nil
+}
+
+// convertComputors converts bob's computor identity list to types.Computors.
+func convertComputors(identities []string, epoch uint16) (types.Computors, error) {
+	var comps types.Computors
+	comps.Epoch = epoch
+
+	for i, identity := range identities {
+		if i >= types.NumberOfComputors {
+			break
+		}
+		pubKey, err := identityToBytes32(identity)
+		if err != nil {
+			return types.Computors{}, fmt.Errorf("computor[%d] identity: %w", i, err)
+		}
+		comps.PubKeys[i] = pubKey
+	}
+
+	// Bob doesn't expose the computor list signature
+	// Signature stays as zero value [64]byte{}
+
+	return comps, nil
+}

--- a/network/bob/convert_test.go
+++ b/network/bob/convert_test.go
@@ -1,0 +1,186 @@
+package bob
+
+import (
+	"testing"
+
+	"github.com/qubic/go-node-connector/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQubicHashToBytes32_ZeroHash(t *testing.T) {
+	// The all-A identity maps to all-zero bytes
+	result, err := qubicHashToBytes32("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, result)
+}
+
+func TestQubicHashToBytes32_Empty(t *testing.T) {
+	result, err := qubicHashToBytes32("")
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, result)
+}
+
+func TestIdentityToBytes32_Empty(t *testing.T) {
+	result, err := identityToBytes32("")
+	require.NoError(t, err)
+	require.Equal(t, [32]byte{}, result)
+}
+
+func TestIdentityToBytes32_Roundtrip(t *testing.T) {
+	// Use a known identity and verify roundtrip
+	identity := "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID"
+	pubKey, err := identityToBytes32(identity)
+	require.NoError(t, err)
+
+	// Convert back
+	var id types.Identity
+	id, err = id.FromPubKey(pubKey, false)
+	require.NoError(t, err)
+	require.Equal(t, identity, string(id))
+}
+
+func TestHexToBytes64(t *testing.T) {
+	hexStr := "0102030405060708091011121314151617181920212223242526272829303132" +
+		"3334353637383940414243444546474849505152535455565758596061626364"
+	result, err := hexToBytes64(hexStr)
+	require.NoError(t, err)
+	require.Equal(t, byte(0x01), result[0])
+	require.Equal(t, byte(0x64), result[63])
+}
+
+func TestHexToBytes64_Empty(t *testing.T) {
+	result, err := hexToBytes64("")
+	require.NoError(t, err)
+	require.Equal(t, [64]byte{}, result)
+}
+
+func TestHexToBytes64_WrongLength(t *testing.T) {
+	_, err := hexToBytes64("0102")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "expected 64 bytes")
+}
+
+func TestConvertVote(t *testing.T) {
+	// Create a bob vote with zero-value digests (all-A qubic hash = zero bytes)
+	zeroHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	v := bobVote{
+		ComputorIndex:                     42,
+		Epoch:                             150,
+		Tick:                              12500000,
+		Millisecond:                       500,
+		Second:                            30,
+		Minute:                            15,
+		Hour:                              12,
+		Day:                               28,
+		Month:                             2,
+		Year:                              25,
+		PrevResourceTestingDigest:         1234,
+		SaltedResourceTestingDigest:       5678,
+		PrevTransactionBodyDigest:         9012,
+		SaltedTransactionBodyDigest:       3456,
+		PrevSpectrumDigest:                zeroHash,
+		PrevUniverseDigest:                zeroHash,
+		PrevComputerDigest:                zeroHash,
+		SaltedSpectrumDigest:              zeroHash,
+		SaltedUniverseDigest:              zeroHash,
+		SaltedComputerDigest:              zeroHash,
+		TransactionDigest:                 zeroHash,
+		ExpectedNextTickTransactionDigest: zeroHash,
+		Signature:                         "0000000000000000000000000000000000000000000000000000000000000000" + "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	result, err := convertVote(v)
+	require.NoError(t, err)
+	require.Equal(t, uint16(42), result.ComputorIndex)
+	require.Equal(t, uint16(150), result.Epoch)
+	require.Equal(t, uint32(12500000), result.Tick)
+	require.Equal(t, uint16(500), result.Millisecond)
+	require.Equal(t, uint32(1234), result.PreviousResourceTestingDigest)
+	require.Equal(t, uint32(5678), result.SaltedResourceTestingDigest)
+	require.Equal(t, uint32(9012), result.PreviousTransactionBodyDigest)
+	require.Equal(t, uint32(3456), result.SaltedTransactionBodyDigest)
+	require.Equal(t, [32]byte{}, result.TxDigest)
+	require.Equal(t, [64]byte{}, result.Signature)
+}
+
+func TestConvertTickData(t *testing.T) {
+	zeroHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	td := bobTickData{
+		ComputorIndex:      5,
+		Epoch:              150,
+		Tick:               12500000,
+		Millisecond:        100,
+		Second:             45,
+		Minute:             30,
+		Hour:               10,
+		Day:                15,
+		Month:              3,
+		Year:               25,
+		Timelock:           zeroHash,
+		TransactionDigests: []string{zeroHash},
+		ContractFees:       jsonFees{100, 200},
+		Signature:          "0000000000000000000000000000000000000000000000000000000000000000" + "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	result, err := convertTickData(td)
+	require.NoError(t, err)
+	require.Equal(t, uint16(5), result.ComputorIndex)
+	require.Equal(t, uint16(150), result.Epoch)
+	require.Equal(t, uint32(12500000), result.Tick)
+	require.Equal(t, [32]byte{}, result.Timelock)
+	require.Equal(t, [32]byte{}, result.TransactionDigests[0])
+	require.Equal(t, int64(100), result.ContractFees[0])
+	require.Equal(t, int64(200), result.ContractFees[1])
+}
+
+func TestConvertComputors(t *testing.T) {
+	identities := []string{
+		"BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID",
+		"BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID",
+	}
+
+	result, err := convertComputors(identities, 150)
+	require.NoError(t, err)
+	require.Equal(t, uint16(150), result.Epoch)
+	// Both identities map to same pubkey
+	require.Equal(t, result.PubKeys[0], result.PubKeys[1])
+	// Remaining should be zero
+	require.Equal(t, [32]byte{}, result.PubKeys[2])
+	// Signature is zero (bob doesn't provide it)
+	require.Equal(t, [64]byte{}, result.Signature)
+}
+
+func TestConvertRPCTransaction(t *testing.T) {
+	tx := bobRPCTransaction{
+		Hash:      "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefgh",
+		From:      "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID",
+		To:        "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID",
+		Amount:    1000000,
+		InputType: 0,
+		InputSize: 0,
+		InputData: "",
+		Signature: "0000000000000000000000000000000000000000000000000000000000000000" + "0000000000000000000000000000000000000000000000000000000000000000",
+	}
+
+	result, err := convertRPCTransaction(tx)
+	require.NoError(t, err)
+	require.Equal(t, int64(1000000), result.Amount)
+	require.Equal(t, uint16(0), result.InputType)
+	require.Equal(t, uint16(0), result.InputSize)
+	require.Nil(t, result.Input)
+	require.Equal(t, [64]byte{}, result.Signature)
+}
+
+func TestJsonFees_UnmarshalJSON_Array(t *testing.T) {
+	var fees jsonFees
+	err := fees.UnmarshalJSON([]byte("[100, 200, 300]"))
+	require.NoError(t, err)
+	require.Equal(t, jsonFees{100, 200, 300}, fees)
+}
+
+func TestJsonFees_UnmarshalJSON_Zero(t *testing.T) {
+	var fees jsonFees
+	err := fees.UnmarshalJSON([]byte("0"))
+	require.NoError(t, err)
+	require.Nil(t, fees)
+}

--- a/network/bob/fetcher.go
+++ b/network/bob/fetcher.go
@@ -20,6 +20,10 @@ type BobDataFetcher struct {
 	cachedTick     uint32
 	cachedTickResp *bobTickResponse
 
+	// Per-cycle cache for executed status (from qubic_getTickByNumber response).
+	// Populated by GetTickTransactions, consumed by GetTxStatus.
+	cachedExecuted     map[string]bool // txHash -> executed
+	cachedExecutedTick uint32
 }
 
 // NewBobDataFetcher creates a new BobDataFetcher.
@@ -99,15 +103,25 @@ func (b *BobDataFetcher) GetTickTransactions(ctx context.Context, tickNumber uin
 	}
 
 	txs := make(types.Transactions, 0, len(rpcTick.Transactions))
+	executedMap := make(map[string]bool, len(rpcTick.Transactions))
 	for i, rpcTx := range rpcTick.Transactions {
 		tx, err := convertRPCTransaction(rpcTx)
 		if err != nil {
 			return nil, fmt.Errorf("converting transaction[%d]: %w", i, err)
 		}
-		// Set the tick number since it's not included per-tx in the RPC response
 		tx.Tick = tickNumber
 		txs = append(txs, tx)
+
+		// Cache the executed status (nil/pending → not in map → treated as false)
+		if rpcTx.Executed != nil {
+			executedMap[rpcTx.Hash] = *rpcTx.Executed
+		}
 	}
+
+	b.mu.Lock()
+	b.cachedExecuted = executedMap
+	b.cachedExecutedTick = tickNumber
+	b.mu.Unlock()
 
 	return txs, nil
 }
@@ -132,7 +146,15 @@ func (b *BobDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.Tr
 		return types.TransactionStatus{}, false, fmt.Errorf("getting tick response for tx status: %w", err)
 	}
 
-	status, err := computeMoneyFlew(ctx, b.client, tickResp, tick)
+	b.mu.Lock()
+	executedMap := b.cachedExecuted
+	b.mu.Unlock()
+
+	if executedMap == nil {
+		executedMap = make(map[string]bool)
+	}
+
+	status, err := computeMoneyFlew(tickResp, executedMap, tick)
 	if err != nil {
 		return types.TransactionStatus{}, false, fmt.Errorf("computing moneyFlew: %w", err)
 	}
@@ -141,10 +163,12 @@ func (b *BobDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.Tr
 }
 
 func (b *BobDataFetcher) Release(_ error) {
-	// Clear per-cycle cache
+	// Clear per-cycle caches
 	b.mu.Lock()
 	b.cachedTick = 0
 	b.cachedTickResp = nil
+	b.cachedExecuted = nil
+	b.cachedExecutedTick = 0
 	b.mu.Unlock()
 }
 

--- a/network/bob/fetcher.go
+++ b/network/bob/fetcher.go
@@ -1,0 +1,168 @@
+package bob
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/qubic/go-archiver-v2/network"
+	"github.com/qubic/go-node-connector/types"
+)
+
+// BobDataFetcher implements network.DataFetcher by fetching data from a bob instance.
+type BobDataFetcher struct {
+	client *Client
+
+	// Per-cycle cache for the tick response (GET /tick/{tick}).
+	// Multiple DataFetcher methods read from the same tick endpoint.
+	mu             sync.Mutex
+	cachedTick     uint32
+	cachedTickResp *bobTickResponse
+}
+
+// NewBobDataFetcher creates a new BobDataFetcher.
+func NewBobDataFetcher(bobURL string) *BobDataFetcher {
+	return &BobDataFetcher{
+		client: NewClient(bobURL),
+	}
+}
+
+func (b *BobDataFetcher) GetTickStatus(ctx context.Context) (network.TickStatus, error) {
+	body, err := b.client.RESTGet(ctx, "/status")
+	if err != nil {
+		return network.TickStatus{}, fmt.Errorf("getting bob status: %w", err)
+	}
+
+	var status bobSyncStatus
+	if err := json.Unmarshal(body, &status); err != nil {
+		return network.TickStatus{}, fmt.Errorf("unmarshalling bob status: %w", err)
+	}
+
+	return network.TickStatus{
+		Epoch:       status.Epoch,
+		Tick:        status.CurrentVerifyLoggingTick,
+		InitialTick: status.InitialTick,
+		// Bob has already validated all data, so report full quorum alignment
+		NumberOfAlignedVotes: 676,
+	}, nil
+}
+
+func (b *BobDataFetcher) GetSystemMetadata(_ context.Context) (network.SystemMetadata, error) {
+	// Bob doesn't expose ComputorPacketSignature or TargetTickVoteSignature.
+	// These are marked as unavailable so the validator knows to skip related checks.
+	// InitialTick is populated from the cached status obtained in GetTickStatus.
+	return network.SystemMetadata{
+		ComputorSignatureAvailable: false,
+		VoteSignatureAvailable:     false,
+	}, nil
+}
+
+func (b *BobDataFetcher) GetQuorumVotes(ctx context.Context, tickNumber uint32) (types.QuorumVotes, error) {
+	tickResp, err := b.getTickResponse(ctx, tickNumber)
+	if err != nil {
+		return nil, fmt.Errorf("getting tick response: %w", err)
+	}
+
+	votes := make(types.QuorumVotes, 0, len(tickResp.Votes))
+	for i, v := range tickResp.Votes {
+		converted, err := convertVote(v)
+		if err != nil {
+			return nil, fmt.Errorf("converting vote[%d]: %w", i, err)
+		}
+		votes = append(votes, converted)
+	}
+
+	return votes, nil
+}
+
+func (b *BobDataFetcher) GetTickData(ctx context.Context, tickNumber uint32) (types.TickData, error) {
+	tickResp, err := b.getTickResponse(ctx, tickNumber)
+	if err != nil {
+		return types.TickData{}, fmt.Errorf("getting tick response: %w", err)
+	}
+
+	return convertTickData(tickResp.TickData)
+}
+
+func (b *BobDataFetcher) GetTickTransactions(ctx context.Context, tickNumber uint32) (types.Transactions, error) {
+	// Use RPC endpoint to get full transactions with signatures
+	result, err := b.client.RPCCall(ctx, "qubic_getTickByNumber", []interface{}{tickNumber, true})
+	if err != nil {
+		return nil, fmt.Errorf("RPC qubic_getTickByNumber: %w", err)
+	}
+
+	var rpcTick bobRPCTickResponse
+	if err := json.Unmarshal(result, &rpcTick); err != nil {
+		return nil, fmt.Errorf("unmarshalling RPC tick response: %w", err)
+	}
+
+	txs := make(types.Transactions, 0, len(rpcTick.Transactions))
+	for i, rpcTx := range rpcTick.Transactions {
+		tx, err := convertRPCTransaction(rpcTx)
+		if err != nil {
+			return nil, fmt.Errorf("converting transaction[%d]: %w", i, err)
+		}
+		// Set the tick number since it's not included per-tx in the RPC response
+		tx.Tick = tickNumber
+		txs = append(txs, tx)
+	}
+
+	return txs, nil
+}
+
+func (b *BobDataFetcher) GetComputors(ctx context.Context) (types.Computors, error) {
+	result, err := b.client.RPCCall(ctx, "qubic_getComputors", []interface{}{})
+	if err != nil {
+		return types.Computors{}, fmt.Errorf("RPC qubic_getComputors: %w", err)
+	}
+
+	var compsResp bobComputorsResponse
+	if err := json.Unmarshal(result, &compsResp); err != nil {
+		return types.Computors{}, fmt.Errorf("unmarshalling computors response: %w", err)
+	}
+
+	return convertComputors(compsResp.Computors, compsResp.Epoch)
+}
+
+func (b *BobDataFetcher) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, bool, error) {
+	// TODO: Compute moneyFlew from bob's log events using qubic_getTransactionReceipt.
+	// For now, return empty status indicating data is not available.
+	return types.TransactionStatus{}, false, nil
+}
+
+func (b *BobDataFetcher) Release(_ error) {
+	// Clear the per-cycle cache
+	b.mu.Lock()
+	b.cachedTick = 0
+	b.cachedTickResp = nil
+	b.mu.Unlock()
+}
+
+// getTickResponse fetches and caches the full tick response from GET /tick/{tick}.
+func (b *BobDataFetcher) getTickResponse(ctx context.Context, tickNumber uint32) (*bobTickResponse, error) {
+	b.mu.Lock()
+	if b.cachedTickResp != nil && b.cachedTick == tickNumber {
+		resp := b.cachedTickResp
+		b.mu.Unlock()
+		return resp, nil
+	}
+	b.mu.Unlock()
+
+	body, err := b.client.RESTGet(ctx, fmt.Sprintf("/tick/%d", tickNumber))
+	if err != nil {
+		return nil, fmt.Errorf("getting tick %d: %w", tickNumber, err)
+	}
+
+	var tickResp bobTickResponse
+	if err := json.Unmarshal(body, &tickResp); err != nil {
+		return nil, fmt.Errorf("unmarshalling tick response: %w", err)
+	}
+
+	b.mu.Lock()
+	b.cachedTick = tickNumber
+	b.cachedTickResp = &tickResp
+	b.mu.Unlock()
+
+	return &tickResp, nil
+}

--- a/network/bob/fetcher.go
+++ b/network/bob/fetcher.go
@@ -20,10 +20,6 @@ type BobDataFetcher struct {
 	cachedTick     uint32
 	cachedTickResp *bobTickResponse
 
-	// Per-cycle cache for transactions (from GetTickTransactions).
-	// Used by GetTxStatus to compute moneyFlew without re-fetching.
-	cachedTxsTick uint32
-	cachedTxs     types.Transactions
 }
 
 // NewBobDataFetcher creates a new BobDataFetcher.
@@ -113,12 +109,6 @@ func (b *BobDataFetcher) GetTickTransactions(ctx context.Context, tickNumber uin
 		txs = append(txs, tx)
 	}
 
-	// Cache for use by GetTxStatus
-	b.mu.Lock()
-	b.cachedTxsTick = tickNumber
-	b.cachedTxs = txs
-	b.mu.Unlock()
-
 	return txs, nil
 }
 
@@ -142,17 +132,7 @@ func (b *BobDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.Tr
 		return types.TransactionStatus{}, false, fmt.Errorf("getting tick response for tx status: %w", err)
 	}
 
-	// Get cached transactions (populated by GetTickTransactions which runs before GetTxStatus)
-	b.mu.Lock()
-	txs := b.cachedTxs
-	txsTick := b.cachedTxsTick
-	b.mu.Unlock()
-
-	if txsTick != tick || txs == nil {
-		return types.TransactionStatus{}, false, fmt.Errorf("transactions for tick %d not cached (have tick %d)", tick, txsTick)
-	}
-
-	status, err := computeMoneyFlew(ctx, b.client, tickResp, txs, tick)
+	status, err := computeMoneyFlew(ctx, b.client, tickResp, tick)
 	if err != nil {
 		return types.TransactionStatus{}, false, fmt.Errorf("computing moneyFlew: %w", err)
 	}
@@ -161,12 +141,10 @@ func (b *BobDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.Tr
 }
 
 func (b *BobDataFetcher) Release(_ error) {
-	// Clear per-cycle caches
+	// Clear per-cycle cache
 	b.mu.Lock()
 	b.cachedTick = 0
 	b.cachedTickResp = nil
-	b.cachedTxsTick = 0
-	b.cachedTxs = nil
 	b.mu.Unlock()
 }
 

--- a/network/bob/fetcher.go
+++ b/network/bob/fetcher.go
@@ -19,6 +19,11 @@ type BobDataFetcher struct {
 	mu             sync.Mutex
 	cachedTick     uint32
 	cachedTickResp *bobTickResponse
+
+	// Per-cycle cache for transactions (from GetTickTransactions).
+	// Used by GetTxStatus to compute moneyFlew without re-fetching.
+	cachedTxsTick uint32
+	cachedTxs     types.Transactions
 }
 
 // NewBobDataFetcher creates a new BobDataFetcher.
@@ -108,6 +113,12 @@ func (b *BobDataFetcher) GetTickTransactions(ctx context.Context, tickNumber uin
 		txs = append(txs, tx)
 	}
 
+	// Cache for use by GetTxStatus
+	b.mu.Lock()
+	b.cachedTxsTick = tickNumber
+	b.cachedTxs = txs
+	b.mu.Unlock()
+
 	return txs, nil
 }
 
@@ -125,17 +136,37 @@ func (b *BobDataFetcher) GetComputors(ctx context.Context) (types.Computors, err
 	return convertComputors(compsResp.Computors, compsResp.Epoch)
 }
 
-func (b *BobDataFetcher) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, bool, error) {
-	// TODO: Compute moneyFlew from bob's log events using qubic_getTransactionReceipt.
-	// For now, return empty status indicating data is not available.
-	return types.TransactionStatus{}, false, nil
+func (b *BobDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.TransactionStatus, bool, error) {
+	tickResp, err := b.getTickResponse(ctx, tick)
+	if err != nil {
+		return types.TransactionStatus{}, false, fmt.Errorf("getting tick response for tx status: %w", err)
+	}
+
+	// Get cached transactions (populated by GetTickTransactions which runs before GetTxStatus)
+	b.mu.Lock()
+	txs := b.cachedTxs
+	txsTick := b.cachedTxsTick
+	b.mu.Unlock()
+
+	if txsTick != tick || txs == nil {
+		return types.TransactionStatus{}, false, fmt.Errorf("transactions for tick %d not cached (have tick %d)", tick, txsTick)
+	}
+
+	status, err := computeMoneyFlew(ctx, b.client, tickResp, txs, tick)
+	if err != nil {
+		return types.TransactionStatus{}, false, fmt.Errorf("computing moneyFlew: %w", err)
+	}
+
+	return status, true, nil
 }
 
 func (b *BobDataFetcher) Release(_ error) {
-	// Clear the per-cycle cache
+	// Clear per-cycle caches
 	b.mu.Lock()
 	b.cachedTick = 0
 	b.cachedTickResp = nil
+	b.cachedTxsTick = 0
+	b.cachedTxs = nil
 	b.mu.Unlock()
 }
 

--- a/network/bob/moneyflew.go
+++ b/network/bob/moneyflew.go
@@ -1,26 +1,16 @@
 package bob
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/qubic/go-node-connector/types"
 )
 
-// bobTxInfoResponse represents the fields we need from bob's GET /tx/{hash} endpoint.
-type bobTxInfoResponse struct {
-	Executed *bool  `json:"executed,omitempty"` // nil when hasIndexedInfo is false
-	Error    string `json:"error,omitempty"`
-}
-
-// computeMoneyFlew determines the moneyFlew status for each transaction in a tick
-// by querying bob's GET /tx/{hash} endpoint and reading the authoritative `executed` flag.
-func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResponse, tickNumber uint32) (types.TransactionStatus, error) {
-	// Collect non-zero transaction digests
+// computeMoneyFlew builds the MoneyFlew bit array from the executed status map.
+// The executedMap is populated from bob's qubic_getTickByNumber response (bob 1.4.0+),
+// where each transaction carries an authoritative `executed` flag.
+func computeMoneyFlew(tickResp *bobTickResponse, executedMap map[string]bool, tickNumber uint32) (types.TransactionStatus, error) {
 	var digestList [][32]byte
-	var txHashes []string
 
 	for i, digestStr := range tickResp.TickData.TransactionDigests {
 		if digestStr == "" {
@@ -31,18 +21,15 @@ func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResp
 			return types.TransactionStatus{}, fmt.Errorf("converting digest[%d]: %w", i, err)
 		}
 		digestList = append(digestList, digest)
-		txHashes = append(txHashes, digestStr) // already lowercase qubic hash
 	}
 
 	var moneyFlew [128]byte
 
-	for i, txHash := range txHashes {
-		executed, err := fetchTxExecuted(ctx, client, txHash)
-		if err != nil {
-			log.Printf("[WARN] failed to fetch executed status for tx %s: %v", txHash, err)
+	for i, digestStr := range tickResp.TickData.TransactionDigests {
+		if digestStr == "" {
 			continue
 		}
-		if executed {
+		if executedMap[digestStr] {
 			setMoneyFlewBit(&moneyFlew, i)
 		}
 	}
@@ -54,29 +41,6 @@ func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResp
 		MoneyFlew:          moneyFlew,
 		TransactionDigests: digestList,
 	}, nil
-}
-
-// fetchTxExecuted queries bob's GET /tx/{hash} and returns the executed flag.
-func fetchTxExecuted(ctx context.Context, client *Client, txHash string) (bool, error) {
-	body, err := client.RESTGet(ctx, fmt.Sprintf("/tx/%s", txHash))
-	if err != nil {
-		return false, fmt.Errorf("GET /tx/%s: %w", txHash, err)
-	}
-
-	var info bobTxInfoResponse
-	if err := json.Unmarshal(body, &info); err != nil {
-		return false, fmt.Errorf("unmarshalling tx info: %w", err)
-	}
-
-	if info.Error != "" {
-		return false, nil // tx not found or error — treat as not executed
-	}
-
-	if info.Executed == nil {
-		return false, nil // not indexed yet — treat as not executed
-	}
-
-	return *info.Executed, nil
 }
 
 // setMoneyFlewBit sets bit at position index in the MoneyFlew byte array.

--- a/network/bob/moneyflew.go
+++ b/network/bob/moneyflew.go
@@ -5,50 +5,23 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/qubic/go-node-connector/types"
 )
 
-const quTransferLogType = 0
-
-// firstQUTransfer holds the fields from the first QU_TRANSFER event for a transaction.
-type firstQUTransfer struct {
-	Source      string // uppercase identity
-	Destination string // uppercase identity
-	Amount      int64
-	Tick        uint32
+// bobTxInfoResponse represents the fields we need from bob's GET /tx/{hash} endpoint.
+type bobTxInfoResponse struct {
+	Executed *bool  `json:"executed,omitempty"` // nil when hasIndexedInfo is false
+	Error    string `json:"error,omitempty"`
 }
 
-// computeMoneyFlew fetches logs for the given tick and computes the moneyFlew
-// status for each transaction by comparing the transaction's fields against its
-// first QU_TRANSFER log event.
-//
-// Algorithm (from bob maintainer):
-//
-//	moneyFlew = (tx.amount == first_event.amount)
-//	         && (tx.src == first_event.src)
-//	         && (tx.dst == first_event.dst)
-//	         && (tx.tick == first_event.tick)
-//
-// Only transactions with amount > 0 are candidates; others default to false.
-func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResponse, txs types.Transactions, tickNumber uint32) (types.TransactionStatus, error) {
-	epoch := tickResp.TickData.Epoch
-	logIdStart := tickResp.TickData.LogIdStart
-	logIdEnd := tickResp.TickData.LogIdEnd
-
-	// Build transaction lookup: txHash -> Transaction
-	txByHash := make(map[string]*types.Transaction, len(txs))
-	for i := range txs {
-		txID, err := txs[i].ID()
-		if err != nil {
-			return types.TransactionStatus{}, fmt.Errorf("computing tx ID for index %d: %w", i, err)
-		}
-		txByHash[txID] = &txs[i]
-	}
-
-	// Collect non-zero transaction digests and build the digest list
+// computeMoneyFlew determines the moneyFlew status for each transaction in a tick
+// by querying bob's GET /tx/{hash} endpoint and reading the authoritative `executed` flag.
+func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResponse, tickNumber uint32) (types.TransactionStatus, error) {
+	// Collect non-zero transaction digests
 	var digestList [][32]byte
+	var txHashes []string
+
 	for i, digestStr := range tickResp.TickData.TransactionDigests {
 		if digestStr == "" {
 			continue
@@ -58,70 +31,18 @@ func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResp
 			return types.TransactionStatus{}, fmt.Errorf("converting digest[%d]: %w", i, err)
 		}
 		digestList = append(digestList, digest)
+		txHashes = append(txHashes, digestStr) // already lowercase qubic hash
 	}
 
-	// Build the MoneyFlew bit array
 	var moneyFlew [128]byte
 
-	// If there are no logs, return with all-zero moneyFlew
-	if logIdStart < 0 || logIdEnd < logIdStart {
-		return types.TransactionStatus{
-			CurrentTickOfNode:  tickNumber,
-			Tick:               tickNumber,
-			TxCount:            uint32(len(digestList)),
-			MoneyFlew:          moneyFlew,
-			TransactionDigests: digestList,
-		}, nil
-	}
-
-	// Fetch all logs for this tick
-	firstTransfers, err := fetchFirstQUTransfers(ctx, client, epoch, logIdStart, logIdEnd)
-	if err != nil {
-		return types.TransactionStatus{}, fmt.Errorf("fetching logs for tick %d: %w", tickNumber, err)
-	}
-
-	// For each transaction digest, determine moneyFlew
-	for i, digest := range digestList {
-		// Convert digest to txHash (60-char lowercase)
-		var id types.Identity
-		id, err := id.FromPubKey(digest, true)
+	for i, txHash := range txHashes {
+		executed, err := fetchTxExecuted(ctx, client, txHash)
 		if err != nil {
-			log.Printf("[WARN] failed to convert digest[%d] to identity: %v", i, err)
+			log.Printf("[WARN] failed to fetch executed status for tx %s: %v", txHash, err)
 			continue
 		}
-		txHash := id.String()
-
-		// Look up the actual transaction
-		tx, hasTx := txByHash[txHash]
-		if !hasTx || tx.Amount <= 0 {
-			continue // moneyFlew stays false
-		}
-
-		// Look up the first QU_TRANSFER for this tx
-		transfer, hasLog := firstTransfers[txHash]
-		if !hasLog {
-			continue // no QU_TRANSFER event -> moneyFlew = false
-		}
-
-		// Convert tx public keys to uppercase identities for comparison
-		var srcID types.Identity
-		srcID, err = srcID.FromPubKey(tx.SourcePublicKey, false)
-		if err != nil {
-			log.Printf("[WARN] failed to convert source pubkey for tx %s: %v", txHash, err)
-			continue
-		}
-		var dstID types.Identity
-		dstID, err = dstID.FromPubKey(tx.DestinationPublicKey, false)
-		if err != nil {
-			log.Printf("[WARN] failed to convert dest pubkey for tx %s: %v", txHash, err)
-			continue
-		}
-
-		// Apply the moneyFlew algorithm
-		if tx.Amount == transfer.Amount &&
-			string(srcID) == transfer.Source &&
-			string(dstID) == transfer.Destination &&
-			tx.Tick == transfer.Tick {
+		if executed {
 			setMoneyFlewBit(&moneyFlew, i)
 		}
 	}
@@ -135,45 +56,27 @@ func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResp
 	}, nil
 }
 
-// fetchFirstQUTransfers fetches all logs for the tick and returns a map of
-// txHash -> first QU_TRANSFER event for that transaction.
-func fetchFirstQUTransfers(ctx context.Context, client *Client, epoch uint16, logIdStart, logIdEnd int64) (map[string]firstQUTransfer, error) {
-	path := fmt.Sprintf("/log/%d/%d/%d", epoch, logIdStart, logIdEnd)
-	body, err := client.RESTGet(ctx, path)
+// fetchTxExecuted queries bob's GET /tx/{hash} and returns the executed flag.
+func fetchTxExecuted(ctx context.Context, client *Client, txHash string) (bool, error) {
+	body, err := client.RESTGet(ctx, fmt.Sprintf("/tx/%s", txHash))
 	if err != nil {
-		return nil, fmt.Errorf("GET %s: %w", path, err)
+		return false, fmt.Errorf("GET /tx/%s: %w", txHash, err)
 	}
 
-	var logs []bobLogEvent
-	if err := json.Unmarshal(body, &logs); err != nil {
-		return nil, fmt.Errorf("unmarshalling logs: %w", err)
+	var info bobTxInfoResponse
+	if err := json.Unmarshal(body, &info); err != nil {
+		return false, fmt.Errorf("unmarshalling tx info: %w", err)
 	}
 
-	result := make(map[string]firstQUTransfer)
-	for _, logEvent := range logs {
-		if !logEvent.OK {
-			continue
-		}
-		if logEvent.Type != quTransferLogType {
-			continue
-		}
-		txHash := strings.ToLower(logEvent.TxHash)
-		if txHash == "" {
-			continue
-		}
-		// Only keep the first QU_TRANSFER per transaction
-		if _, exists := result[txHash]; exists {
-			continue
-		}
-		result[txHash] = firstQUTransfer{
-			Source:      logEvent.Body.From,
-			Destination: logEvent.Body.To,
-			Amount:      logEvent.Body.Amount,
-			Tick:        logEvent.Tick,
-		}
+	if info.Error != "" {
+		return false, nil // tx not found or error — treat as not executed
 	}
 
-	return result, nil
+	if info.Executed == nil {
+		return false, nil // not indexed yet — treat as not executed
+	}
+
+	return *info.Executed, nil
 }
 
 // setMoneyFlewBit sets bit at position index in the MoneyFlew byte array.

--- a/network/bob/moneyflew.go
+++ b/network/bob/moneyflew.go
@@ -1,0 +1,184 @@
+package bob
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/qubic/go-node-connector/types"
+)
+
+const quTransferLogType = 0
+
+// firstQUTransfer holds the fields from the first QU_TRANSFER event for a transaction.
+type firstQUTransfer struct {
+	Source      string // uppercase identity
+	Destination string // uppercase identity
+	Amount      int64
+	Tick        uint32
+}
+
+// computeMoneyFlew fetches logs for the given tick and computes the moneyFlew
+// status for each transaction by comparing the transaction's fields against its
+// first QU_TRANSFER log event.
+//
+// Algorithm (from bob maintainer):
+//
+//	moneyFlew = (tx.amount == first_event.amount)
+//	         && (tx.src == first_event.src)
+//	         && (tx.dst == first_event.dst)
+//	         && (tx.tick == first_event.tick)
+//
+// Only transactions with amount > 0 are candidates; others default to false.
+func computeMoneyFlew(ctx context.Context, client *Client, tickResp *bobTickResponse, txs types.Transactions, tickNumber uint32) (types.TransactionStatus, error) {
+	epoch := tickResp.TickData.Epoch
+	logIdStart := tickResp.TickData.LogIdStart
+	logIdEnd := tickResp.TickData.LogIdEnd
+
+	// Build transaction lookup: txHash -> Transaction
+	txByHash := make(map[string]*types.Transaction, len(txs))
+	for i := range txs {
+		txID, err := txs[i].ID()
+		if err != nil {
+			return types.TransactionStatus{}, fmt.Errorf("computing tx ID for index %d: %w", i, err)
+		}
+		txByHash[txID] = &txs[i]
+	}
+
+	// Collect non-zero transaction digests and build the digest list
+	var digestList [][32]byte
+	for i, digestStr := range tickResp.TickData.TransactionDigests {
+		if digestStr == "" {
+			continue
+		}
+		digest, err := qubicHashToBytes32(digestStr)
+		if err != nil {
+			return types.TransactionStatus{}, fmt.Errorf("converting digest[%d]: %w", i, err)
+		}
+		digestList = append(digestList, digest)
+	}
+
+	// Build the MoneyFlew bit array
+	var moneyFlew [128]byte
+
+	// If there are no logs, return with all-zero moneyFlew
+	if logIdStart < 0 || logIdEnd < logIdStart {
+		return types.TransactionStatus{
+			CurrentTickOfNode:  tickNumber,
+			Tick:               tickNumber,
+			TxCount:            uint32(len(digestList)),
+			MoneyFlew:          moneyFlew,
+			TransactionDigests: digestList,
+		}, nil
+	}
+
+	// Fetch all logs for this tick
+	firstTransfers, err := fetchFirstQUTransfers(ctx, client, epoch, logIdStart, logIdEnd)
+	if err != nil {
+		return types.TransactionStatus{}, fmt.Errorf("fetching logs for tick %d: %w", tickNumber, err)
+	}
+
+	// For each transaction digest, determine moneyFlew
+	for i, digest := range digestList {
+		// Convert digest to txHash (60-char lowercase)
+		var id types.Identity
+		id, err := id.FromPubKey(digest, true)
+		if err != nil {
+			log.Printf("[WARN] failed to convert digest[%d] to identity: %v", i, err)
+			continue
+		}
+		txHash := id.String()
+
+		// Look up the actual transaction
+		tx, hasTx := txByHash[txHash]
+		if !hasTx || tx.Amount <= 0 {
+			continue // moneyFlew stays false
+		}
+
+		// Look up the first QU_TRANSFER for this tx
+		transfer, hasLog := firstTransfers[txHash]
+		if !hasLog {
+			continue // no QU_TRANSFER event -> moneyFlew = false
+		}
+
+		// Convert tx public keys to uppercase identities for comparison
+		var srcID types.Identity
+		srcID, err = srcID.FromPubKey(tx.SourcePublicKey, false)
+		if err != nil {
+			log.Printf("[WARN] failed to convert source pubkey for tx %s: %v", txHash, err)
+			continue
+		}
+		var dstID types.Identity
+		dstID, err = dstID.FromPubKey(tx.DestinationPublicKey, false)
+		if err != nil {
+			log.Printf("[WARN] failed to convert dest pubkey for tx %s: %v", txHash, err)
+			continue
+		}
+
+		// Apply the moneyFlew algorithm
+		if tx.Amount == transfer.Amount &&
+			string(srcID) == transfer.Source &&
+			string(dstID) == transfer.Destination &&
+			tx.Tick == transfer.Tick {
+			setMoneyFlewBit(&moneyFlew, i)
+		}
+	}
+
+	return types.TransactionStatus{
+		CurrentTickOfNode:  tickNumber,
+		Tick:               tickNumber,
+		TxCount:            uint32(len(digestList)),
+		MoneyFlew:          moneyFlew,
+		TransactionDigests: digestList,
+	}, nil
+}
+
+// fetchFirstQUTransfers fetches all logs for the tick and returns a map of
+// txHash -> first QU_TRANSFER event for that transaction.
+func fetchFirstQUTransfers(ctx context.Context, client *Client, epoch uint16, logIdStart, logIdEnd int64) (map[string]firstQUTransfer, error) {
+	path := fmt.Sprintf("/log/%d/%d/%d", epoch, logIdStart, logIdEnd)
+	body, err := client.RESTGet(ctx, path)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", path, err)
+	}
+
+	var logs []bobLogEvent
+	if err := json.Unmarshal(body, &logs); err != nil {
+		return nil, fmt.Errorf("unmarshalling logs: %w", err)
+	}
+
+	result := make(map[string]firstQUTransfer)
+	for _, logEvent := range logs {
+		if !logEvent.OK {
+			continue
+		}
+		if logEvent.Type != quTransferLogType {
+			continue
+		}
+		txHash := strings.ToLower(logEvent.TxHash)
+		if txHash == "" {
+			continue
+		}
+		// Only keep the first QU_TRANSFER per transaction
+		if _, exists := result[txHash]; exists {
+			continue
+		}
+		result[txHash] = firstQUTransfer{
+			Source:      logEvent.Body.From,
+			Destination: logEvent.Body.To,
+			Amount:      logEvent.Body.Amount,
+			Tick:        logEvent.Tick,
+		}
+	}
+
+	return result, nil
+}
+
+// setMoneyFlewBit sets bit at position index in the MoneyFlew byte array.
+func setMoneyFlewBit(moneyFlew *[128]byte, index int) {
+	bytePos := index / 8
+	bitPos := index % 8
+	moneyFlew[bytePos] |= 1 << bitPos
+}

--- a/network/bob/moneyflew_test.go
+++ b/network/bob/moneyflew_test.go
@@ -1,0 +1,297 @@
+package bob
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/qubic/go-node-connector/types"
+	"github.com/stretchr/testify/require"
+)
+
+// testIdentity is a known Qubic identity for testing.
+const testIdentityA = "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID"
+const testIdentityB = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACNKL"
+
+func pubKeyForIdentity(t *testing.T, identity string, lowercase bool) [32]byte {
+	t.Helper()
+	id := types.Identity(identity)
+	pk, err := id.ToPubKey(lowercase)
+	require.NoError(t, err)
+	return pk
+}
+
+func makeTx(t *testing.T, src, dst string, amount int64, tick uint32) types.Transaction {
+	t.Helper()
+	return types.Transaction{
+		SourcePublicKey:      pubKeyForIdentity(t, src, false),
+		DestinationPublicKey: pubKeyForIdentity(t, dst, false),
+		Amount:               amount,
+		Tick:                 tick,
+		InputType:            0,
+		InputSize:            0,
+		Signature:            [64]byte{},
+	}
+}
+
+func TestSetMoneyFlewBit(t *testing.T) {
+	var bits [128]byte
+	setMoneyFlewBit(&bits, 0)
+	require.Equal(t, byte(1), bits[0])
+
+	setMoneyFlewBit(&bits, 7)
+	require.Equal(t, byte(0x81), bits[0])
+
+	setMoneyFlewBit(&bits, 8)
+	require.Equal(t, byte(1), bits[1])
+}
+
+func TestFetchFirstQUTransfers(t *testing.T) {
+	logs := []bobLogEvent{
+		{OK: true, Type: 0, Tick: 100, TxHash: "txhash1", Body: bobLogBody{From: "SRC1", To: "DST1", Amount: 500}},
+		{OK: true, Type: 0, Tick: 100, TxHash: "txhash1", Body: bobLogBody{From: "SRC1", To: "DST1", Amount: 200}}, // second event, should be ignored
+		{OK: true, Type: 1, Tick: 100, TxHash: "txhash2", Body: bobLogBody{}},                                       // not QU_TRANSFER
+		{OK: true, Type: 0, Tick: 100, TxHash: "txhash3", Body: bobLogBody{From: "SRC3", To: "DST3", Amount: 1000}},
+		{OK: false, Type: 0, Tick: 100, TxHash: "txhash4", Body: bobLogBody{From: "SRC4", To: "DST4", Amount: 100}}, // not OK
+	}
+
+	logsJSON, err := json.Marshal(logs)
+	require.NoError(t, err)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(logsJSON)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	result, err := fetchFirstQUTransfers(context.Background(), client, 150, 1, 5)
+	require.NoError(t, err)
+
+	// txhash1: first event kept (amount 500), second ignored
+	require.Contains(t, result, "txhash1")
+	require.Equal(t, int64(500), result["txhash1"].Amount)
+	require.Equal(t, "SRC1", result["txhash1"].Source)
+	require.Equal(t, "DST1", result["txhash1"].Destination)
+
+	// txhash2: not QU_TRANSFER, not included
+	require.NotContains(t, result, "txhash2")
+
+	// txhash3: included
+	require.Contains(t, result, "txhash3")
+	require.Equal(t, int64(1000), result["txhash3"].Amount)
+
+	// txhash4: not OK, not included
+	require.NotContains(t, result, "txhash4")
+}
+
+func TestComputeMoneyFlew_MatchingTransfer(t *testing.T) {
+	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
+	txID, err := tx.ID()
+	require.NoError(t, err)
+
+	// The tx digest as qubic hash (lowercase)
+	txDigest, err := tx.Digest()
+	require.NoError(t, err)
+	var digestID types.Identity
+	digestID, err = digestID.FromPubKey(txDigest, true)
+	require.NoError(t, err)
+	digestHash := digestID.String()
+
+	logs := []bobLogEvent{
+		{
+			OK:     true,
+			Type:   0,
+			Tick:   100,
+			TxHash: txID,
+			Body: bobLogBody{
+				From:   testIdentityA,
+				To:     testIdentityB,
+				Amount: 1000,
+			},
+		},
+	}
+	logsJSON, _ := json.Marshal(logs)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(logsJSON)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch:              150,
+			Tick:               100,
+			LogIdStart:         1,
+			LogIdEnd:           1,
+			TransactionDigests: []string{digestHash},
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint32(1), status.TxCount)
+	require.Len(t, status.TransactionDigests, 1)
+	// Bit 0 should be set (moneyFlew = true)
+	require.Equal(t, byte(1), status.MoneyFlew[0]&1)
+}
+
+func TestComputeMoneyFlew_ZeroAmount(t *testing.T) {
+	tx := makeTx(t, testIdentityA, testIdentityB, 0, 100)
+
+	txDigest, err := tx.Digest()
+	require.NoError(t, err)
+	var digestID types.Identity
+	digestID, err = digestID.FromPubKey(txDigest, true)
+	require.NoError(t, err)
+	digestHash := digestID.String()
+
+	// Even with a matching log, amount=0 should give moneyFlew=false
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch:              150,
+			Tick:               100,
+			LogIdStart:         1,
+			LogIdEnd:           1,
+			TransactionDigests: []string{digestHash},
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false for zero-amount tx")
+}
+
+func TestComputeMoneyFlew_MismatchedAmount(t *testing.T) {
+	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
+	txID, err := tx.ID()
+	require.NoError(t, err)
+
+	txDigest, err := tx.Digest()
+	require.NoError(t, err)
+	var digestID types.Identity
+	digestID, err = digestID.FromPubKey(txDigest, true)
+	require.NoError(t, err)
+	digestHash := digestID.String()
+
+	// Log has different amount -> moneyFlew = false
+	logs := []bobLogEvent{
+		{OK: true, Type: 0, Tick: 100, TxHash: txID, Body: bobLogBody{
+			From: testIdentityA, To: testIdentityB, Amount: 999,
+		}},
+	}
+	logsJSON, _ := json.Marshal(logs)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(logsJSON)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch: 150, Tick: 100, LogIdStart: 1, LogIdEnd: 1,
+			TransactionDigests: []string{digestHash},
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when amount mismatches")
+}
+
+func TestComputeMoneyFlew_NoLogs(t *testing.T) {
+	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
+
+	txDigest, err := tx.Digest()
+	require.NoError(t, err)
+	var digestID types.Identity
+	digestID, err = digestID.FromPubKey(txDigest, true)
+	require.NoError(t, err)
+	digestHash := digestID.String()
+
+	// logIdStart < 0 means no logs for this tick
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch: 150, Tick: 100, LogIdStart: -1, LogIdEnd: -1,
+			TransactionDigests: []string{digestHash},
+		},
+	}
+
+	// No HTTP call should be made
+	status, err := computeMoneyFlew(context.Background(), nil, tickResp, types.Transactions{tx}, 100)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when no logs")
+}
+
+func TestComputeMoneyFlew_MismatchedDestination(t *testing.T) {
+	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
+	txID, err := tx.ID()
+	require.NoError(t, err)
+
+	txDigest, err := tx.Digest()
+	require.NoError(t, err)
+	var digestID types.Identity
+	digestID, err = digestID.FromPubKey(txDigest, true)
+	require.NoError(t, err)
+	digestHash := digestID.String()
+
+	// Log has correct src and amount but wrong destination
+	logs := []bobLogEvent{
+		{OK: true, Type: 0, Tick: 100, TxHash: txID, Body: bobLogBody{
+			From: testIdentityA, To: testIdentityA, Amount: 1000, // wrong dst
+		}},
+	}
+	logsJSON, _ := json.Marshal(logs)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, string(logsJSON))
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch: 150, Tick: 100, LogIdStart: 1, LogIdEnd: 1,
+			TransactionDigests: []string{digestHash},
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when destination mismatches")
+}
+
+func TestComputeMoneyFlew_EmptyTick(t *testing.T) {
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch: 150, Tick: 100, LogIdStart: -1, LogIdEnd: -1,
+			TransactionDigests: nil,
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), nil, tickResp, nil, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0), status.TxCount)
+	require.Empty(t, status.TransactionDigests)
+	require.Equal(t, [128]byte{}, status.MoneyFlew)
+}

--- a/network/bob/moneyflew_test.go
+++ b/network/bob/moneyflew_test.go
@@ -2,40 +2,14 @@ package bob
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
-	"github.com/qubic/go-node-connector/types"
 	"github.com/stretchr/testify/require"
 )
-
-// testIdentity is a known Qubic identity for testing.
-const testIdentityA = "BAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARMID"
-const testIdentityB = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACNKL"
-
-func pubKeyForIdentity(t *testing.T, identity string, lowercase bool) [32]byte {
-	t.Helper()
-	id := types.Identity(identity)
-	pk, err := id.ToPubKey(lowercase)
-	require.NoError(t, err)
-	return pk
-}
-
-func makeTx(t *testing.T, src, dst string, amount int64, tick uint32) types.Transaction {
-	t.Helper()
-	return types.Transaction{
-		SourcePublicKey:      pubKeyForIdentity(t, src, false),
-		DestinationPublicKey: pubKeyForIdentity(t, dst, false),
-		Amount:               amount,
-		Tick:                 tick,
-		InputType:            0,
-		InputSize:            0,
-		Signature:            [64]byte{},
-	}
-}
 
 func TestSetMoneyFlewBit(t *testing.T) {
 	var bits [128]byte
@@ -49,76 +23,63 @@ func TestSetMoneyFlewBit(t *testing.T) {
 	require.Equal(t, byte(1), bits[1])
 }
 
-func TestFetchFirstQUTransfers(t *testing.T) {
-	logs := []bobLogEvent{
-		{OK: true, Type: 0, Tick: 100, TxHash: "txhash1", Body: bobLogBody{From: "SRC1", To: "DST1", Amount: 500}},
-		{OK: true, Type: 0, Tick: 100, TxHash: "txhash1", Body: bobLogBody{From: "SRC1", To: "DST1", Amount: 200}}, // second event, should be ignored
-		{OK: true, Type: 1, Tick: 100, TxHash: "txhash2", Body: bobLogBody{}},                                       // not QU_TRANSFER
-		{OK: true, Type: 0, Tick: 100, TxHash: "txhash3", Body: bobLogBody{From: "SRC3", To: "DST3", Amount: 1000}},
-		{OK: false, Type: 0, Tick: 100, TxHash: "txhash4", Body: bobLogBody{From: "SRC4", To: "DST4", Amount: 100}}, // not OK
-	}
-
-	logsJSON, err := json.Marshal(logs)
-	require.NoError(t, err)
-
+func TestFetchTxExecuted_True(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(logsJSON)
+		fmt.Fprint(w, `{"hash":"abc","executed":true}`)
 	}))
 	defer server.Close()
 
 	client := NewClient(server.URL)
-	result, err := fetchFirstQUTransfers(context.Background(), client, 150, 1, 5)
+	executed, err := fetchTxExecuted(context.Background(), client, "abc")
 	require.NoError(t, err)
-
-	// txhash1: first event kept (amount 500), second ignored
-	require.Contains(t, result, "txhash1")
-	require.Equal(t, int64(500), result["txhash1"].Amount)
-	require.Equal(t, "SRC1", result["txhash1"].Source)
-	require.Equal(t, "DST1", result["txhash1"].Destination)
-
-	// txhash2: not QU_TRANSFER, not included
-	require.NotContains(t, result, "txhash2")
-
-	// txhash3: included
-	require.Contains(t, result, "txhash3")
-	require.Equal(t, int64(1000), result["txhash3"].Amount)
-
-	// txhash4: not OK, not included
-	require.NotContains(t, result, "txhash4")
+	require.True(t, executed)
 }
 
-func TestComputeMoneyFlew_MatchingTransfer(t *testing.T) {
-	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
-	txID, err := tx.ID()
-	require.NoError(t, err)
+func TestFetchTxExecuted_False(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"hash":"abc","executed":false}`)
+	}))
+	defer server.Close()
 
-	// The tx digest as qubic hash (lowercase)
-	txDigest, err := tx.Digest()
+	client := NewClient(server.URL)
+	executed, err := fetchTxExecuted(context.Background(), client, "abc")
 	require.NoError(t, err)
-	var digestID types.Identity
-	digestID, err = digestID.FromPubKey(txDigest, true)
-	require.NoError(t, err)
-	digestHash := digestID.String()
+	require.False(t, executed)
+}
 
-	logs := []bobLogEvent{
-		{
-			OK:     true,
-			Type:   0,
-			Tick:   100,
-			TxHash: txID,
-			Body: bobLogBody{
-				From:   testIdentityA,
-				To:     testIdentityB,
-				Amount: 1000,
-			},
-		},
-	}
-	logsJSON, _ := json.Marshal(logs)
+func TestFetchTxExecuted_NotIndexed(t *testing.T) {
+	// When hasIndexedInfo is false, "executed" field is absent
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"hash":"abc","amount":1000}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	executed, err := fetchTxExecuted(context.Background(), client, "abc")
+	require.NoError(t, err)
+	require.False(t, executed)
+}
+
+func TestFetchTxExecuted_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `{"error":"Transaction not found"}`)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	executed, err := fetchTxExecuted(context.Background(), client, "abc")
+	require.NoError(t, err)
+	require.False(t, executed)
+}
+
+func TestComputeMoneyFlew_WithExecutedTx(t *testing.T) {
+	// Use a known qubic hash as the tx digest
+	txHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(logsJSON)
+		if strings.Contains(r.URL.Path, "/tx/") {
+			fmt.Fprint(w, `{"hash":"abc","executed":true}`)
+		}
 	}))
 	defer server.Close()
 
@@ -128,34 +89,24 @@ func TestComputeMoneyFlew_MatchingTransfer(t *testing.T) {
 		TickData: bobTickData{
 			Epoch:              150,
 			Tick:               100,
-			LogIdStart:         1,
-			LogIdEnd:           1,
-			TransactionDigests: []string{digestHash},
+			TransactionDigests: []string{txHash},
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
 	require.NoError(t, err)
 	require.Equal(t, uint32(1), status.TxCount)
 	require.Len(t, status.TransactionDigests, 1)
-	// Bit 0 should be set (moneyFlew = true)
-	require.Equal(t, byte(1), status.MoneyFlew[0]&1)
+	require.Equal(t, byte(1), status.MoneyFlew[0]&1, "moneyFlew should be true")
 }
 
-func TestComputeMoneyFlew_ZeroAmount(t *testing.T) {
-	tx := makeTx(t, testIdentityA, testIdentityB, 0, 100)
+func TestComputeMoneyFlew_WithNotExecutedTx(t *testing.T) {
+	txHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
 
-	txDigest, err := tx.Digest()
-	require.NoError(t, err)
-	var digestID types.Identity
-	digestID, err = digestID.FromPubKey(txDigest, true)
-	require.NoError(t, err)
-	digestHash := digestID.String()
-
-	// Even with a matching log, amount=0 should give moneyFlew=false
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte("[]"))
+		if strings.Contains(r.URL.Path, "/tx/") {
+			fmt.Fprint(w, `{"hash":"abc","executed":false}`)
+		}
 	}))
 	defer server.Close()
 
@@ -165,133 +116,60 @@ func TestComputeMoneyFlew_ZeroAmount(t *testing.T) {
 		TickData: bobTickData{
 			Epoch:              150,
 			Tick:               100,
-			LogIdStart:         1,
-			LogIdEnd:           1,
-			TransactionDigests: []string{digestHash},
+			TransactionDigests: []string{txHash},
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
 	require.NoError(t, err)
-	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false for zero-amount tx")
-}
-
-func TestComputeMoneyFlew_MismatchedAmount(t *testing.T) {
-	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
-	txID, err := tx.ID()
-	require.NoError(t, err)
-
-	txDigest, err := tx.Digest()
-	require.NoError(t, err)
-	var digestID types.Identity
-	digestID, err = digestID.FromPubKey(txDigest, true)
-	require.NoError(t, err)
-	digestHash := digestID.String()
-
-	// Log has different amount -> moneyFlew = false
-	logs := []bobLogEvent{
-		{OK: true, Type: 0, Tick: 100, TxHash: txID, Body: bobLogBody{
-			From: testIdentityA, To: testIdentityB, Amount: 999,
-		}},
-	}
-	logsJSON, _ := json.Marshal(logs)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.Write(logsJSON)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	tickResp := &bobTickResponse{
-		Tick: 100,
-		TickData: bobTickData{
-			Epoch: 150, Tick: 100, LogIdStart: 1, LogIdEnd: 1,
-			TransactionDigests: []string{digestHash},
-		},
-	}
-
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
-	require.NoError(t, err)
-	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when amount mismatches")
-}
-
-func TestComputeMoneyFlew_NoLogs(t *testing.T) {
-	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
-
-	txDigest, err := tx.Digest()
-	require.NoError(t, err)
-	var digestID types.Identity
-	digestID, err = digestID.FromPubKey(txDigest, true)
-	require.NoError(t, err)
-	digestHash := digestID.String()
-
-	// logIdStart < 0 means no logs for this tick
-	tickResp := &bobTickResponse{
-		Tick: 100,
-		TickData: bobTickData{
-			Epoch: 150, Tick: 100, LogIdStart: -1, LogIdEnd: -1,
-			TransactionDigests: []string{digestHash},
-		},
-	}
-
-	// No HTTP call should be made
-	status, err := computeMoneyFlew(context.Background(), nil, tickResp, types.Transactions{tx}, 100)
-	require.NoError(t, err)
-	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when no logs")
-}
-
-func TestComputeMoneyFlew_MismatchedDestination(t *testing.T) {
-	tx := makeTx(t, testIdentityA, testIdentityB, 1000, 100)
-	txID, err := tx.ID()
-	require.NoError(t, err)
-
-	txDigest, err := tx.Digest()
-	require.NoError(t, err)
-	var digestID types.Identity
-	digestID, err = digestID.FromPubKey(txDigest, true)
-	require.NoError(t, err)
-	digestHash := digestID.String()
-
-	// Log has correct src and amount but wrong destination
-	logs := []bobLogEvent{
-		{OK: true, Type: 0, Tick: 100, TxHash: txID, Body: bobLogBody{
-			From: testIdentityA, To: testIdentityA, Amount: 1000, // wrong dst
-		}},
-	}
-	logsJSON, _ := json.Marshal(logs)
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, string(logsJSON))
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	tickResp := &bobTickResponse{
-		Tick: 100,
-		TickData: bobTickData{
-			Epoch: 150, Tick: 100, LogIdStart: 1, LogIdEnd: 1,
-			TransactionDigests: []string{digestHash},
-		},
-	}
-
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, types.Transactions{tx}, 100)
-	require.NoError(t, err)
-	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false when destination mismatches")
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false")
 }
 
 func TestComputeMoneyFlew_EmptyTick(t *testing.T) {
 	tickResp := &bobTickResponse{
 		Tick: 100,
 		TickData: bobTickData{
-			Epoch: 150, Tick: 100, LogIdStart: -1, LogIdEnd: -1,
+			Epoch:              150,
+			Tick:               100,
 			TransactionDigests: nil,
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), nil, tickResp, nil, 100)
+	status, err := computeMoneyFlew(context.Background(), nil, tickResp, 100)
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), status.TxCount)
 	require.Empty(t, status.TransactionDigests)
 	require.Equal(t, [128]byte{}, status.MoneyFlew)
+}
+
+func TestComputeMoneyFlew_MultipleTxs_MixedStatus(t *testing.T) {
+	txHash1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
+	txHash2 := "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarmid"
+
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			fmt.Fprint(w, `{"hash":"tx1","executed":true}`)
+		} else {
+			fmt.Fprint(w, `{"hash":"tx2","executed":false}`)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL)
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch:              150,
+			Tick:               100,
+			TransactionDigests: []string{txHash1, txHash2},
+		},
+	}
+
+	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
+	require.NoError(t, err)
+	require.Equal(t, uint32(2), status.TxCount)
+	require.Equal(t, byte(1), status.MoneyFlew[0]&1, "first tx should be executed")
+	require.Equal(t, byte(0), status.MoneyFlew[0]&2, "second tx should not be executed")
 }

--- a/network/bob/moneyflew_test.go
+++ b/network/bob/moneyflew_test.go
@@ -1,11 +1,6 @@
 package bob
 
 import (
-	"context"
-	"fmt"
-	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,67 +18,8 @@ func TestSetMoneyFlewBit(t *testing.T) {
 	require.Equal(t, byte(1), bits[1])
 }
 
-func TestFetchTxExecuted_True(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"hash":"abc","executed":true}`)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	executed, err := fetchTxExecuted(context.Background(), client, "abc")
-	require.NoError(t, err)
-	require.True(t, executed)
-}
-
-func TestFetchTxExecuted_False(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"hash":"abc","executed":false}`)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	executed, err := fetchTxExecuted(context.Background(), client, "abc")
-	require.NoError(t, err)
-	require.False(t, executed)
-}
-
-func TestFetchTxExecuted_NotIndexed(t *testing.T) {
-	// When hasIndexedInfo is false, "executed" field is absent
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"hash":"abc","amount":1000}`)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	executed, err := fetchTxExecuted(context.Background(), client, "abc")
-	require.NoError(t, err)
-	require.False(t, executed)
-}
-
-func TestFetchTxExecuted_Error(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, `{"error":"Transaction not found"}`)
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
-	executed, err := fetchTxExecuted(context.Background(), client, "abc")
-	require.NoError(t, err)
-	require.False(t, executed)
-}
-
-func TestComputeMoneyFlew_WithExecutedTx(t *testing.T) {
-	// Use a known qubic hash as the tx digest
+func TestComputeMoneyFlew_Executed(t *testing.T) {
 	txHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/tx/") {
-			fmt.Fprint(w, `{"hash":"abc","executed":true}`)
-		}
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
 	tickResp := &bobTickResponse{
 		Tick: 100,
 		TickData: bobTickData{
@@ -93,24 +29,16 @@ func TestComputeMoneyFlew_WithExecutedTx(t *testing.T) {
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
+	executedMap := map[string]bool{txHash: true}
+	status, err := computeMoneyFlew(tickResp, executedMap, 100)
 	require.NoError(t, err)
 	require.Equal(t, uint32(1), status.TxCount)
 	require.Len(t, status.TransactionDigests, 1)
 	require.Equal(t, byte(1), status.MoneyFlew[0]&1, "moneyFlew should be true")
 }
 
-func TestComputeMoneyFlew_WithNotExecutedTx(t *testing.T) {
+func TestComputeMoneyFlew_NotExecuted(t *testing.T) {
 	txHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
-
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if strings.Contains(r.URL.Path, "/tx/") {
-			fmt.Fprint(w, `{"hash":"abc","executed":false}`)
-		}
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
 	tickResp := &bobTickResponse{
 		Tick: 100,
 		TickData: bobTickData{
@@ -120,9 +48,28 @@ func TestComputeMoneyFlew_WithNotExecutedTx(t *testing.T) {
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
+	executedMap := map[string]bool{txHash: false}
+	status, err := computeMoneyFlew(tickResp, executedMap, 100)
 	require.NoError(t, err)
 	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false")
+}
+
+func TestComputeMoneyFlew_Pending(t *testing.T) {
+	txHash := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
+	tickResp := &bobTickResponse{
+		Tick: 100,
+		TickData: bobTickData{
+			Epoch:              150,
+			Tick:               100,
+			TransactionDigests: []string{txHash},
+		},
+	}
+
+	// Pending (null executed) → not in map → treated as false
+	executedMap := map[string]bool{}
+	status, err := computeMoneyFlew(tickResp, executedMap, 100)
+	require.NoError(t, err)
+	require.Equal(t, byte(0), status.MoneyFlew[0]&1, "moneyFlew should be false for pending")
 }
 
 func TestComputeMoneyFlew_EmptyTick(t *testing.T) {
@@ -135,7 +82,7 @@ func TestComputeMoneyFlew_EmptyTick(t *testing.T) {
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), nil, tickResp, 100)
+	status, err := computeMoneyFlew(tickResp, nil, 100)
 	require.NoError(t, err)
 	require.Equal(t, uint32(0), status.TxCount)
 	require.Empty(t, status.TransactionDigests)
@@ -146,18 +93,6 @@ func TestComputeMoneyFlew_MultipleTxs_MixedStatus(t *testing.T) {
 	txHash1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaafxib"
 	txHash2 := "baaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaarmid"
 
-	callCount := 0
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
-		if callCount == 1 {
-			fmt.Fprint(w, `{"hash":"tx1","executed":true}`)
-		} else {
-			fmt.Fprint(w, `{"hash":"tx2","executed":false}`)
-		}
-	}))
-	defer server.Close()
-
-	client := NewClient(server.URL)
 	tickResp := &bobTickResponse{
 		Tick: 100,
 		TickData: bobTickData{
@@ -167,7 +102,12 @@ func TestComputeMoneyFlew_MultipleTxs_MixedStatus(t *testing.T) {
 		},
 	}
 
-	status, err := computeMoneyFlew(context.Background(), client, tickResp, 100)
+	executedMap := map[string]bool{
+		txHash1: true,
+		txHash2: false,
+	}
+
+	status, err := computeMoneyFlew(tickResp, executedMap, 100)
 	require.NoError(t, err)
 	require.Equal(t, uint32(2), status.TxCount)
 	require.Equal(t, byte(1), status.MoneyFlew[0]&1, "first tx should be executed")

--- a/network/bob/types.go
+++ b/network/bob/types.go
@@ -95,29 +95,6 @@ type bobComputorsResponse struct {
 	Computors  []string `json:"computors"` // 60-char uppercase identity strings
 }
 
-// bobLogEvent represents a single log event from bob's GET /log/{epoch}/{from}/{to} endpoint.
-type bobLogEvent struct {
-	OK          bool       `json:"ok"`
-	Epoch       uint16     `json:"epoch"`
-	Tick        uint32     `json:"tick"`
-	Type        uint32     `json:"type"`
-	LogID       uint64     `json:"logId"`
-	LogDigest   string     `json:"logDigest"`
-	BodySize    uint32     `json:"bodySize"`
-	LogTypename string     `json:"logTypename"`
-	Body        bobLogBody `json:"body"`
-	TxHash      string     `json:"txHash"`
-	Timestamp   uint64     `json:"timestamp"`
-}
-
-// bobLogBody represents the body of a log event. Fields vary by log type.
-// For QU_TRANSFER (type 0): From, To, Amount are populated.
-type bobLogBody struct {
-	From   string `json:"from,omitempty"`   // uppercase identity
-	To     string `json:"to,omitempty"`     // uppercase identity
-	Amount int64  `json:"amount,omitempty"` // QU amount
-}
-
 // bobRPCTransaction represents a transaction from qubic_getTickByNumber (RPC format).
 // This format includes the signature, unlike the REST /tx/{hash} endpoint.
 type bobRPCTransaction struct {

--- a/network/bob/types.go
+++ b/network/bob/types.go
@@ -95,6 +95,29 @@ type bobComputorsResponse struct {
 	Computors  []string `json:"computors"` // 60-char uppercase identity strings
 }
 
+// bobLogEvent represents a single log event from bob's GET /log/{epoch}/{from}/{to} endpoint.
+type bobLogEvent struct {
+	OK          bool       `json:"ok"`
+	Epoch       uint16     `json:"epoch"`
+	Tick        uint32     `json:"tick"`
+	Type        uint32     `json:"type"`
+	LogID       uint64     `json:"logId"`
+	LogDigest   string     `json:"logDigest"`
+	BodySize    uint32     `json:"bodySize"`
+	LogTypename string     `json:"logTypename"`
+	Body        bobLogBody `json:"body"`
+	TxHash      string     `json:"txHash"`
+	Timestamp   uint64     `json:"timestamp"`
+}
+
+// bobLogBody represents the body of a log event. Fields vary by log type.
+// For QU_TRANSFER (type 0): From, To, Amount are populated.
+type bobLogBody struct {
+	From   string `json:"from,omitempty"`   // uppercase identity
+	To     string `json:"to,omitempty"`     // uppercase identity
+	Amount int64  `json:"amount,omitempty"` // QU amount
+}
+
 // bobRPCTransaction represents a transaction from qubic_getTickByNumber (RPC format).
 // This format includes the signature, unlike the REST /tx/{hash} endpoint.
 type bobRPCTransaction struct {

--- a/network/bob/types.go
+++ b/network/bob/types.go
@@ -1,0 +1,123 @@
+package bob
+
+import "encoding/json"
+
+// bobTickResponse represents the full response from GET /tick/{tick_number}.
+type bobTickResponse struct {
+	Tick     uint32       `json:"tick"`
+	TickData bobTickData  `json:"tickdata"`
+	Votes    []bobVote    `json:"votes"`
+}
+
+// bobTickData represents tick data from bob's REST API.
+type bobTickData struct {
+	ComputorIndex      uint16   `json:"computorIndex"`
+	Epoch              uint16   `json:"epoch"`
+	Tick               uint32   `json:"tick"`
+	IsSkipped          bool     `json:"isSkipped"`
+	Millisecond        uint16   `json:"millisecond"`
+	Second             uint8    `json:"second"`
+	Minute             uint8    `json:"minute"`
+	Hour               uint8    `json:"hour"`
+	Day                uint8    `json:"day"`
+	Month              uint8    `json:"month"`
+	Year               uint8    `json:"year"`
+	Timelock           string   `json:"timelock"`           // qubic hash encoded (60-char lowercase)
+	TransactionDigests []string `json:"transactionDigests"` // qubic hash encoded
+	ContractFees       jsonFees `json:"contractFees"`       // can be 0 (number) or array of int64
+	Signature          string   `json:"signature"`          // hex encoded (128 chars)
+	LogIdStart         int64    `json:"logIdStart"`
+	LogIdEnd           int64    `json:"logIdEnd"`
+}
+
+// jsonFees handles bob's contractFees field which can be either 0 (number) or an array.
+type jsonFees []int64
+
+func (f *jsonFees) UnmarshalJSON(data []byte) error {
+	// Try as array first
+	var arr []int64
+	if err := json.Unmarshal(data, &arr); err == nil {
+		*f = arr
+		return nil
+	}
+	// If it's a single number (0), treat as empty
+	var n int64
+	if err := json.Unmarshal(data, &n); err == nil {
+		*f = nil
+		return nil
+	}
+	return nil
+}
+
+// bobVote represents a quorum vote from bob's REST API.
+type bobVote struct {
+	ComputorIndex                    uint16 `json:"computorIndex"`
+	Epoch                            uint16 `json:"epoch"`
+	Tick                             uint32 `json:"tick"`
+	Millisecond                      uint16 `json:"millisecond"`
+	Second                           uint8  `json:"second"`
+	Minute                           uint8  `json:"minute"`
+	Hour                             uint8  `json:"hour"`
+	Day                              uint8  `json:"day"`
+	Month                            uint8  `json:"month"`
+	Year                             uint8  `json:"year"`
+	PrevResourceTestingDigest        uint32 `json:"prevResourceTestingDigest"`
+	SaltedResourceTestingDigest      uint32 `json:"saltedResourceTestingDigest"`
+	PrevTransactionBodyDigest        uint32 `json:"prevTransactionBodyDigest"`
+	SaltedTransactionBodyDigest      uint32 `json:"saltedTransactionBodyDigest"`
+	PrevSpectrumDigest               string `json:"prevSpectrumDigest"`               // qubic hash
+	PrevUniverseDigest               string `json:"prevUniverseDigest"`               // qubic hash
+	PrevComputerDigest               string `json:"prevComputerDigest"`               // qubic hash
+	SaltedSpectrumDigest             string `json:"saltedSpectrumDigest"`             // qubic hash
+	SaltedUniverseDigest             string `json:"saltedUniverseDigest"`             // qubic hash
+	SaltedComputerDigest             string `json:"saltedComputerDigest"`             // qubic hash
+	TransactionDigest                string `json:"transactionDigest"`                // qubic hash
+	ExpectedNextTickTransactionDigest string `json:"expectedNextTickTransactionDigest"` // qubic hash
+	Signature                        string `json:"signature"`                        // hex encoded
+}
+
+// bobSyncStatus represents the response from GET /status.
+type bobSyncStatus struct {
+	Epoch                      uint16  `json:"epoch"`
+	InitialTick                uint32  `json:"initialTick"`
+	CurrentFetchingTick        uint32  `json:"currentFetchingTick"`
+	CurrentFetchingLogTick     uint32  `json:"currentFetchingLogTick"`
+	CurrentVerifyLoggingTick   uint32  `json:"currentVerifyLoggingTick"`
+	CurrentIndexingTick        uint32  `json:"currentIndexingTick"`
+	LastSeenNetworkTick        uint32  `json:"lastSeenNetworkTick"`
+	IsSyncing                  bool    `json:"isSyncing"`
+	Progress                   float64 `json:"progress"`
+}
+
+// bobComputorsResponse represents the response from qubic_getComputors.
+type bobComputorsResponse struct {
+	Epoch      uint16   `json:"epoch"`
+	Computors  []string `json:"computors"` // 60-char uppercase identity strings
+}
+
+// bobRPCTransaction represents a transaction from qubic_getTickByNumber (RPC format).
+// This format includes the signature, unlike the REST /tx/{hash} endpoint.
+type bobRPCTransaction struct {
+	Hash      string `json:"hash"`      // 60-char lowercase
+	From      string `json:"from"`      // 60-char uppercase identity
+	To        string `json:"to"`        // 60-char uppercase identity
+	Amount    int64  `json:"amount"`
+	InputType uint16 `json:"inputType"`
+	InputSize uint16 `json:"inputSize"`
+	InputData string `json:"inputData"` // hex encoded
+	Signature string `json:"signature"` // hex encoded (128 chars)
+}
+
+// bobRPCTickResponse represents the response from qubic_getTickByNumber with includeTransactions=true.
+type bobRPCTickResponse struct {
+	TickNumber       uint32              `json:"tickNumber"`
+	Epoch            uint16              `json:"epoch"`
+	ComputorIndex    uint16              `json:"computorIndex"`
+	Signature        string              `json:"signature"`     // hex
+	TickHash         string              `json:"tickHash"`      // hex
+	Timestamp        uint64              `json:"timestamp"`
+	Millisecond      uint16              `json:"millisecond"`
+	Timelock         string              `json:"timelock"`      // hex
+	TransactionCount int                 `json:"transactionCount"`
+	Transactions     []bobRPCTransaction `json:"transactions"`
+}

--- a/network/bob/types.go
+++ b/network/bob/types.go
@@ -96,7 +96,7 @@ type bobComputorsResponse struct {
 }
 
 // bobRPCTransaction represents a transaction from qubic_getTickByNumber (RPC format).
-// This format includes the signature, unlike the REST /tx/{hash} endpoint.
+// As of bob 1.4.0, includes the executed field (tri-state: true/false/null for pending).
 type bobRPCTransaction struct {
 	Hash      string `json:"hash"`      // 60-char lowercase
 	From      string `json:"from"`      // 60-char uppercase identity
@@ -106,6 +106,7 @@ type bobRPCTransaction struct {
 	InputSize uint16 `json:"inputSize"`
 	InputData string `json:"inputData"` // hex encoded
 	Signature string `json:"signature"` // hex encoded (128 chars)
+	Executed  *bool  `json:"executed"`  // nil = pending, true = success, false = failed
 }
 
 // bobRPCTickResponse represents the response from qubic_getTickByNumber with includeTransactions=true.

--- a/network/data_fetcher.go
+++ b/network/data_fetcher.go
@@ -1,0 +1,58 @@
+package network
+
+import (
+	"context"
+
+	"github.com/qubic/go-node-connector/types"
+)
+
+// TickStatus represents current network tick/epoch information.
+type TickStatus struct {
+	Epoch                uint16
+	Tick                 uint32
+	InitialTick          uint32
+	NumberOfAlignedVotes uint16
+}
+
+// SystemMetadata contains system-level metadata needed for validation.
+// For backends that don't provide certain fields (e.g. bob), the Available
+// flags indicate which fields are meaningful.
+type SystemMetadata struct {
+	InitialTick                uint32
+	ComputorPacketSignature    uint64
+	TargetTickVoteSignature    uint32
+	ComputorSignatureAvailable bool // false for bob
+	VoteSignatureAvailable     bool // false for bob
+}
+
+// DataFetcher abstracts all data fetching needed by the processing pipeline.
+// Implementations exist for both Qubic core nodes (NodeDataFetcher) and
+// bob JSON-RPC (BobDataFetcher).
+type DataFetcher interface {
+	// GetTickStatus returns current network tick/epoch info.
+	GetTickStatus(ctx context.Context) (TickStatus, error)
+
+	// GetSystemMetadata returns system-level metadata needed for validation.
+	GetSystemMetadata(ctx context.Context) (SystemMetadata, error)
+
+	// GetQuorumVotes fetches quorum votes for a given tick.
+	GetQuorumVotes(ctx context.Context, tickNumber uint32) (types.QuorumVotes, error)
+
+	// GetTickData fetches tick data for a given tick.
+	GetTickData(ctx context.Context, tickNumber uint32) (types.TickData, error)
+
+	// GetTickTransactions fetches transactions for a given tick.
+	GetTickTransactions(ctx context.Context, tickNumber uint32) (types.Transactions, error)
+
+	// GetComputors fetches the current computor list.
+	GetComputors(ctx context.Context) (types.Computors, error)
+
+	// GetTxStatus fetches transaction status for a given tick.
+	// The bool return indicates whether the data is real (true) or a stub (false).
+	GetTxStatus(ctx context.Context, tick uint32) (types.TransactionStatus, bool, error)
+
+	// Release signals that the current fetch cycle is done.
+	// For node-connector: returns connections to pool or closes on error.
+	// For bob: no-op.
+	Release(err error)
+}

--- a/network/node_fetcher.go
+++ b/network/node_fetcher.go
@@ -1,0 +1,117 @@
+package network
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"github.com/qubic/go-node-connector/types"
+)
+
+// NodeDataFetcher implements DataFetcher by wrapping a QubicClientPool and
+// acquiring two connections (Main/Alt) per processing cycle, preserving the
+// existing two-client pattern used by the validator.
+type NodeDataFetcher struct {
+	pool QubicClientPool
+	main QubicClient
+	alt  QubicClient
+}
+
+// NewNodeDataFetcher creates a new NodeDataFetcher that acquires two clients
+// from the pool. Call Release() when done.
+func NewNodeDataFetcher(pool QubicClientPool) (*NodeDataFetcher, error) {
+	main, err := pool.Get()
+	if err != nil {
+		return nil, fmt.Errorf("getting 1st client connection: %w", err)
+	}
+
+	alt, err := pool.Get()
+	if err != nil {
+		// close the first client if we fail to get the second
+		cErr := pool.Close(main)
+		if cErr != nil {
+			log.Printf("[ERROR] closing 1st client after 2nd client acquisition failure: %s", cErr.Error())
+		}
+		return nil, fmt.Errorf("getting 2nd client connection: %w", err)
+	}
+
+	return &NodeDataFetcher{
+		pool: pool,
+		main: main,
+		alt:  alt,
+	}, nil
+}
+
+func (n *NodeDataFetcher) GetTickStatus(ctx context.Context) (TickStatus, error) {
+	tickInfo, err := n.main.GetTickInfo(ctx)
+	if err != nil {
+		return TickStatus{}, fmt.Errorf("getting tick info: %w", err)
+	}
+	return TickStatus{
+		Epoch:                tickInfo.Epoch,
+		Tick:                 tickInfo.Tick,
+		InitialTick:          tickInfo.InitialTick,
+		NumberOfAlignedVotes: tickInfo.NumberOfAlignedVotes,
+	}, nil
+}
+
+func (n *NodeDataFetcher) GetSystemMetadata(ctx context.Context) (SystemMetadata, error) {
+	systemInfo, err := n.alt.GetSystemInfo(ctx)
+	if err != nil {
+		return SystemMetadata{}, fmt.Errorf("getting system info: %w", err)
+	}
+	return SystemMetadata{
+		InitialTick:                systemInfo.InitialTick,
+		ComputorPacketSignature:    systemInfo.ComputorPacketSignature,
+		TargetTickVoteSignature:    systemInfo.TargetTickVoteSignature,
+		ComputorSignatureAvailable: true,
+		VoteSignatureAvailable:     true,
+	}, nil
+}
+
+func (n *NodeDataFetcher) GetQuorumVotes(ctx context.Context, tickNumber uint32) (types.QuorumVotes, error) {
+	return n.main.GetQuorumVotes(ctx, tickNumber)
+}
+
+func (n *NodeDataFetcher) GetTickData(ctx context.Context, tickNumber uint32) (types.TickData, error) {
+	return n.alt.GetTickData(ctx, tickNumber)
+}
+
+func (n *NodeDataFetcher) GetTickTransactions(ctx context.Context, tickNumber uint32) (types.Transactions, error) {
+	return n.main.GetTickTransactions(ctx, tickNumber)
+}
+
+func (n *NodeDataFetcher) GetComputors(ctx context.Context) (types.Computors, error) {
+	return n.main.GetComputors(ctx)
+}
+
+func (n *NodeDataFetcher) GetTxStatus(ctx context.Context, tick uint32) (types.TransactionStatus, bool, error) {
+	status, err := n.main.GetTxStatus(ctx, tick)
+	if err != nil {
+		return types.TransactionStatus{}, false, err
+	}
+	return status, true, nil
+}
+
+func (n *NodeDataFetcher) Release(err error) {
+	n.releaseClient(err, n.main)
+	n.releaseClient(err, n.alt)
+}
+
+func (n *NodeDataFetcher) releaseClient(err error, client QubicClient) {
+	if client == nil {
+		return
+	}
+	if err == nil {
+		pErr := n.pool.Put(client)
+		if pErr != nil {
+			log.Printf("[ERROR] putting connection back to pool: %s", pErr.Error())
+		}
+	} else {
+		log.Printf("Closing connection because of error: %v", err)
+		cErr := n.pool.Close(client)
+		if cErr != nil {
+			log.Printf("[ERROR] closing connection: %s", cErr.Error())
+		}
+	}
+}

--- a/processor/processor.go
+++ b/processor/processor.go
@@ -11,12 +11,10 @@ import (
 	"github.com/qubic/go-archiver-v2/metrics"
 	"github.com/qubic/go-archiver-v2/network"
 	"github.com/qubic/go-archiver-v2/protobuf"
-	"github.com/qubic/go-archiver-v2/validator"
-	"github.com/qubic/go-node-connector/types"
 )
 
 type Validator interface {
-	Validate(ctx context.Context, store *db.PebbleStore, client validator.Clients, epoch uint16, tickNumber uint32) error
+	Validate(ctx context.Context, store *db.PebbleStore, fetcher network.DataFetcher, epoch uint16, tickNumber uint32) error
 }
 
 type TickStatus struct {
@@ -27,7 +25,7 @@ type TickStatus struct {
 }
 
 type Processor struct {
-	clientPool           network.QubicClientPool
+	fetcherFactory       func() (network.DataFetcher, error)
 	databasePool         *db.DatabasePool
 	tickValidator        Validator
 	arbitratorPubKey     [32]byte
@@ -41,9 +39,9 @@ type Config struct {
 	ProcessTickTimeout time.Duration
 }
 
-func NewProcessor(clientPool network.QubicClientPool, dbPool *db.DatabasePool, tickValidator Validator, config Config, metrics *metrics.ProcessingMetrics) *Processor {
+func NewProcessor(fetcherFactory func() (network.DataFetcher, error), dbPool *db.DatabasePool, tickValidator Validator, config Config, metrics *metrics.ProcessingMetrics) *Processor {
 	return &Processor{
-		clientPool:         clientPool,
+		fetcherFactory:     fetcherFactory,
 		databasePool:       dbPool,
 		processTickTimeout: config.ProcessTickTimeout,
 		tickValidator:      tickValidator,
@@ -72,64 +70,55 @@ func (p *Processor) processOneByOne() error {
 	defer cancel()
 
 	var err error
-	client, err := p.clientPool.Get()
+	fetcher, err := p.fetcherFactory()
 	if err != nil {
-		return fmt.Errorf("getting 1st client connection: %w", err)
+		return fmt.Errorf("creating data fetcher: %w", err)
 	}
 	defer func() {
-		p.releaseClient(err, client)
+		fetcher.Release(err)
 	}()
 
-	alternativeClient, err := p.clientPool.Get()
+	tickStatus, err := fetcher.GetTickStatus(ctx)
 	if err != nil {
-		return fmt.Errorf("getting 2nd client connection: %w", err)
+		return fmt.Errorf("getting tick status: %w", err)
 	}
-	defer func() {
-		p.releaseClient(err, alternativeClient)
-	}()
+	p.tickStatus.LiveTick = tickStatus.Tick
+	p.tickStatus.LiveEpoch = tickStatus.Epoch
 
-	tickInfo, err := client.GetTickInfo(ctx)
-	if err != nil {
-		return fmt.Errorf("getting tick info: %w", err)
-	}
-	p.tickStatus.LiveTick = tickInfo.Tick
-	p.tickStatus.LiveEpoch = tickInfo.Epoch
-
-	dataStore, err := p.databasePool.GetOrCreateDbForEpoch(tickInfo.Epoch)
+	dataStore, err := p.databasePool.GetOrCreateDbForEpoch(tickStatus.Epoch)
 	if err != nil {
 		return fmt.Errorf("getting database: %w", err)
 	}
 
-	lastProcessedTick, err := p.getLastProcessedTick(ctx, dataStore, tickInfo.Epoch)
+	lastProcessedTick, err := p.getLastProcessedTick(ctx, dataStore, tickStatus.Epoch)
 	if err != nil {
 		return fmt.Errorf("getting last processed tick: %w", err)
 	}
 	p.tickStatus.ProcessedTick = lastProcessedTick.TickNumber
 	p.tickStatus.ProcessingEpoch = uint16(lastProcessedTick.Epoch)
 
-	nextTick, err := p.getNextProcessingTick(ctx, lastProcessedTick, tickInfo)
+	nextTick, err := p.getNextProcessingTick(ctx, lastProcessedTick, tickStatus)
 	if err != nil {
 		return fmt.Errorf("getting next tick to process: %w", err)
 	}
-	log.Printf("Next tick to process: [%d]. Current tick: [%d]. Delta [%d]", nextTick.TickNumber, tickInfo.Tick, int64(tickInfo.Tick)-int64(nextTick.TickNumber))
+	log.Printf("Next tick to process: [%d]. Current tick: [%d]. Delta [%d]", nextTick.TickNumber, tickStatus.Tick, int64(tickStatus.Tick)-int64(nextTick.TickNumber))
 
-	if nextTick.TickNumber > tickInfo.Tick {
+	if nextTick.TickNumber > tickStatus.Tick {
 		return fmt.Errorf("next tick is in the future. processed: %d, next %d, available %d",
-			lastProcessedTick.TickNumber, nextTick.TickNumber, tickInfo.Tick)
+			lastProcessedTick.TickNumber, nextTick.TickNumber, tickStatus.Tick)
 	}
 
 	// not sure if this helps because we will often be aligned at time of processing
-	if nextTick.TickNumber == tickInfo.Tick && tickInfo.NumberOfAlignedVotes < 451 {
-		return fmt.Errorf("tick not ready ([%d] aligned votes)", tickInfo.NumberOfAlignedVotes)
+	if nextTick.TickNumber == tickStatus.Tick && tickStatus.NumberOfAlignedVotes < 451 {
+		return fmt.Errorf("tick not ready ([%d] aligned votes)", tickStatus.NumberOfAlignedVotes)
 	}
 
-	clients := validator.Clients{Main: client, Alt: alternativeClient}
-	err = p.tickValidator.Validate(ctx, dataStore, clients, tickInfo.Epoch, nextTick.TickNumber)
+	err = p.tickValidator.Validate(ctx, dataStore, fetcher, tickStatus.Epoch, nextTick.TickNumber)
 	if err != nil {
 		return fmt.Errorf("validating tick %d: %w", nextTick.TickNumber, err)
 	}
 
-	if lastProcessedTick.TickNumber >= tickInfo.InitialTick { // no skipped ticks before initial tick
+	if lastProcessedTick.TickNumber >= tickStatus.InitialTick { // no skipped ticks before initial tick
 		err = p.handleTickIntervals(ctx, dataStore, lastProcessedTick, nextTick)
 		if err != nil {
 			return fmt.Errorf("handling skipped ticks: %w", err)
@@ -148,21 +137,6 @@ func (p *Processor) processOneByOne() error {
 	return nil
 }
 
-func (p *Processor) releaseClient(err error, client network.QubicClient) {
-	if err == nil {
-		pErr := p.clientPool.Put(client)
-		if pErr != nil {
-			log.Printf("[ERROR] putting connection back to pool: %s", pErr.Error())
-		}
-	} else {
-		log.Printf("Closing connection because of error: %v", err)
-		cErr := p.clientPool.Close(client)
-		if cErr != nil {
-			log.Printf("[ERROR] closing connection: %s", cErr.Error())
-		}
-	}
-}
-
 func (p *Processor) getLastProcessedTick(ctx context.Context, dataStore *db.PebbleStore, epoch uint16) (*protobuf.ProcessedTick, error) {
 
 	lastTick, err := dataStore.GetLastProcessedTick(ctx)
@@ -177,11 +151,11 @@ func (p *Processor) getLastProcessedTick(ctx context.Context, dataStore *db.Pebb
 	return lastTick, nil
 }
 
-func (p *Processor) getNextProcessingTick(_ context.Context, lastTick *protobuf.ProcessedTick, currentTickInfo types.TickInfo) (*protobuf.ProcessedTick, error) {
+func (p *Processor) getNextProcessingTick(_ context.Context, lastTick *protobuf.ProcessedTick, currentTickStatus network.TickStatus) (*protobuf.ProcessedTick, error) {
 	// handles the case where the initial tick of epoch returned by the node is greater than the last processed tick
 	// which means that we are in the next epoch, and we should start from the initial tick of the current epoch
-	if currentTickInfo.InitialTick > lastTick.TickNumber {
-		return &protobuf.ProcessedTick{TickNumber: currentTickInfo.InitialTick, Epoch: uint32(currentTickInfo.Epoch)}, nil
+	if currentTickStatus.InitialTick > lastTick.TickNumber {
+		return &protobuf.ProcessedTick{TickNumber: currentTickStatus.InitialTick, Epoch: uint32(currentTickStatus.Epoch)}, nil
 	}
 
 	// otherwise we are in the same epoch, and we should start from the last processed tick + 1

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -10,126 +10,61 @@ import (
 	"github.com/qubic/go-archiver-v2/db"
 	"github.com/qubic/go-archiver-v2/metrics"
 	"github.com/qubic/go-archiver-v2/network"
-	"github.com/qubic/go-archiver-v2/validator"
-	qubic "github.com/qubic/go-node-connector"
 	"github.com/qubic/go-node-connector/types"
 	"github.com/stretchr/testify/require"
 )
 
-type TestPool struct {
-	client network.QubicClient
+type TestFetcher struct {
+	epoch       uint16
+	tick        uint32
+	initialTick uint32
 }
 
-func (t *TestPool) Get() (network.QubicClient, error) {
-	return t.client, nil
+func (f *TestFetcher) GetTickStatus(_ context.Context) (network.TickStatus, error) {
+	return network.TickStatus{
+		Epoch:                f.epoch,
+		Tick:                 f.tick,
+		InitialTick:          f.initialTick,
+		NumberOfAlignedVotes: 500,
+	}, nil
 }
 
-func (t *TestPool) Put(_ network.QubicClient) error {
-	log.Println("Returning client")
-	return nil
+func (f *TestFetcher) GetSystemMetadata(_ context.Context) (network.SystemMetadata, error) {
+	return network.SystemMetadata{
+		InitialTick:                f.initialTick,
+		ComputorSignatureAvailable: true,
+		VoteSignatureAvailable:     true,
+	}, nil
 }
 
-func (t *TestPool) Close(_ network.QubicClient) error {
-	log.Println("Closing client")
-	return nil
+func (f *TestFetcher) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
+	panic("not implemented")
+}
+
+func (f *TestFetcher) GetTickData(_ context.Context, _ uint32) (types.TickData, error) {
+	panic("not implemented")
+}
+
+func (f *TestFetcher) GetTickTransactions(_ context.Context, _ uint32) (types.Transactions, error) {
+	panic("not implemented")
+}
+
+func (f *TestFetcher) GetComputors(_ context.Context) (types.Computors, error) {
+	panic("not implemented")
+}
+
+func (f *TestFetcher) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, bool, error) {
+	panic("not implemented")
+}
+
+func (f *TestFetcher) Release(_ error) {
+	log.Println("Releasing fetcher")
 }
 
 type TestValidator struct{}
 
-func (t TestValidator) Validate(_ context.Context, _ *db.PebbleStore, _ validator.Clients, epoch uint16, tickNumber uint32) error {
+func (t TestValidator) Validate(_ context.Context, _ *db.PebbleStore, _ network.DataFetcher, epoch uint16, tickNumber uint32) error {
 	log.Printf("Mock validated tick [%d] in epoch [%d].", tickNumber, epoch)
-	return nil
-}
-
-type TestClient struct {
-	epoch       uint16
-	tick        uint32
-	InitialTick uint32
-}
-
-func (t *TestClient) GetIssuedAssets(_ context.Context, _ string) (types.IssuedAssets, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetPossessedAssets(_ context.Context, _ string) (types.PossessedAssets, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetOwnedAssets(_ context.Context, _ string) (types.OwnedAssets, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetIdentity(_ context.Context, _ string) (types.AddressInfo, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetTickInfo(_ context.Context) (types.TickInfo, error) {
-	return types.TickInfo{
-		Epoch:                t.epoch,
-		Tick:                 t.tick,
-		NumberOfAlignedVotes: 500,
-		InitialTick:          t.InitialTick,
-	}, nil
-}
-
-func (t *TestClient) GetSystemInfo(_ context.Context) (types.SystemInfo, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetTickData(_ context.Context, _ uint32) (types.TickData, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetTickTransactions(_ context.Context, _ uint32) (types.Transactions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) SendRawTransaction(_ context.Context, _ []byte) error {
-	panic("implement me")
-}
-
-func (t *TestClient) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetComputors(_ context.Context) (types.Computors, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) QuerySmartContract(_ context.Context, _ qubic.RequestContractFunction, _ []byte) (types.SmartContractData, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetPossessionsByFilter(_ context.Context, _, _, _, _ string, _, _ uint16) (types.AssetPossessions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetOwnershipsByFilter(_ context.Context, _, _, _ string, _ uint16) (types.AssetOwnerships, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetIssuancesByFilter(_ context.Context, _, _ string) (types.AssetIssuances, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetIssuancesByUniverseIndex(_ context.Context, _ uint32) (types.AssetIssuances, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetOwnershipsByUniverseIndex(_ context.Context, _ uint32) (types.AssetOwnerships, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetPossessionsByUniverseIndex(_ context.Context, _ uint32) (types.AssetPossessions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) Close() error {
-	log.Println("Closing client")
 	return nil
 }
 
@@ -138,19 +73,19 @@ var (
 )
 
 func TestProcessor_processOneByOne(t *testing.T) {
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		epoch:       42,
 		tick:        101,
-		InitialTick: 100,
+		initialTick: 100,
 	}
-	clientPool := &TestPool{
-		client: client,
+	fetcherFactory := func() (network.DataFetcher, error) {
+		return fetcher, nil
 	}
 	testDir := t.TempDir()
 	dataPool, err := db.NewDatabasePool(testDir, 5)
 	require.NoError(t, err)
 
-	processor := NewProcessor(clientPool, dataPool, &TestValidator{}, Config{time.Millisecond}, dummyMetrics)
+	processor := NewProcessor(fetcherFactory, dataPool, &TestValidator{}, Config{time.Millisecond}, dummyMetrics)
 	err = processor.processOneByOne()
 	require.NoError(t, err)
 	err = processor.processOneByOne()
@@ -160,19 +95,19 @@ func TestProcessor_processOneByOne(t *testing.T) {
 }
 
 func TestProcessor_processOneByOne_epochChange(t *testing.T) {
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		epoch:       42,
 		tick:        101,
-		InitialTick: 100,
+		initialTick: 100,
 	}
-	clientPool := &TestPool{
-		client: client,
+	fetcherFactory := func() (network.DataFetcher, error) {
+		return fetcher, nil
 	}
 	testDir := t.TempDir()
 	dataPool, err := db.NewDatabasePool(testDir, 5)
 	require.NoError(t, err)
 
-	processor := NewProcessor(clientPool, dataPool, &TestValidator{}, Config{time.Millisecond}, dummyMetrics)
+	processor := NewProcessor(fetcherFactory, dataPool, &TestValidator{}, Config{time.Millisecond}, dummyMetrics)
 	err = processor.processOneByOne()
 	require.NoError(t, err)
 	err = processor.processOneByOne()
@@ -181,9 +116,9 @@ func TestProcessor_processOneByOne_epochChange(t *testing.T) {
 	require.ErrorContains(t, err, "next tick is in the future")
 
 	// new epoch
-	client.epoch = 43
-	client.tick = 202
-	client.InitialTick = 200
+	fetcher.epoch = 43
+	fetcher.tick = 202
+	fetcher.initialTick = 200
 
 	err = processor.processOneByOne()
 	require.NoError(t, err)

--- a/validator/computors/data_access.go
+++ b/validator/computors/data_access.go
@@ -12,16 +12,31 @@ import (
 	"github.com/qubic/go-archiver-v2/network"
 )
 
-// Get computors list
-func Get(ctx context.Context, store *db.PebbleStore, client network.QubicClient, tickNumber, initialTick uint32, epoch uint16, computorSignaturePackage uint64) ([]*Computors, error) {
+// Get fetches the computors list. When computorSignatureAvailable is false (e.g. bob backend),
+// computors are fetched once per epoch without signature-change detection.
+func Get(ctx context.Context, store *db.PebbleStore, fetcher network.DataFetcher, tickNumber, initialTick uint32, epoch uint16, computorSignaturePackage uint64, computorSignatureAvailable bool) ([]*Computors, error) {
 	compsList, err := load(ctx, store, uint32(epoch))
 	if err != nil {
 		return nil, fmt.Errorf("loading computors from data store: %w", err)
 	}
 
-	//Start of epoch
+	if !computorSignatureAvailable {
+		// Bob path: fetch once at epoch start, skip signature-change detection
+		if compsList == nil || len(compsList) == 0 {
+			computors, err := getFromFetcher(ctx, fetcher, initialTick)
+			if err != nil {
+				return nil, fmt.Errorf("getting computors from fetcher: %w", err)
+			}
+			computors.Validated = true // trust the data source
+			log.Printf("[INFO] Computors list from non-node source. Epoch: [%d]", epoch)
+			return []*Computors{computors}, nil
+		}
+		return compsList, nil
+	}
+
+	// Node path: use signature-change detection
 	if compsList == nil || len(compsList) == 0 {
-		computors, err := getFromNode(ctx, client, initialTick)
+		computors, err := getFromFetcher(ctx, fetcher, initialTick)
 		if err != nil {
 			return nil, fmt.Errorf("getting computors from node: %w", err)
 		}
@@ -36,7 +51,7 @@ func Get(ctx context.Context, store *db.PebbleStore, client network.QubicClient,
 	lastComputorList := compsList[len(compsList)-1]
 	lastComputorSignaturePackage := binary.LittleEndian.Uint64(lastComputorList.Signature[:8])
 	if computorSignaturePackage != lastComputorSignaturePackage {
-		computors, err := getFromNode(ctx, client, tickNumber)
+		computors, err := getFromFetcher(ctx, fetcher, tickNumber)
 		if err != nil {
 			return nil, fmt.Errorf("getting computors from node: %w", err)
 		}
@@ -62,8 +77,8 @@ func load(ctx context.Context, store *db.PebbleStore, epoch uint32) ([]*Computor
 	return model, nil
 }
 
-func getFromNode(ctx context.Context, client network.QubicClient, tickNumber uint32) (*Computors, error) {
-	comps, err := client.GetComputors(ctx)
+func getFromFetcher(ctx context.Context, fetcher network.DataFetcher, tickNumber uint32) (*Computors, error) {
+	comps, err := fetcher.GetComputors(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get computors call: %w", err)
 	}

--- a/validator/computors/data_access_test.go
+++ b/validator/computors/data_access_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/qubic/go-archiver-v2/db"
-	qubic "github.com/qubic/go-node-connector"
+	"github.com/qubic/go-archiver-v2/network"
 	"github.com/qubic/go-node-connector/types"
 	"github.com/stretchr/testify/require"
 )
@@ -31,14 +31,14 @@ func TestComputorsDataAccess_WhenGet_GivenStoredInDb_ThenLoadFromDb(t *testing.T
 		Signature: [64]byte{},
 	}
 
-	client := TestClient{
+	fetcher := &TestFetcher{
 		computors: computors,
 	}
 
 	err = Save(context.Background(), dataStore, 42, computorsList)
 	require.NoError(t, err)
 
-	loaded, err := Get(context.Background(), dataStore, &client, 0, 0, 42, 0)
+	loaded, err := Get(context.Background(), dataStore, fetcher, 0, 0, 42, 0, true)
 	require.NoError(t, err)
 
 	diff := cmp.Diff(loaded, computorsList)
@@ -56,11 +56,11 @@ func TestComputorsDataAccess_WhenGet_GiveNotStored_ThenLoadClient(t *testing.T) 
 		Signature: [64]byte{},
 	}
 
-	client := TestClient{
+	fetcher := &TestFetcher{
 		computors: computors,
 	}
 
-	loaded, err := Get(context.Background(), dataStore, &client, 0, 0, 42, 0)
+	loaded, err := Get(context.Background(), dataStore, fetcher, 0, 0, 42, 0, true)
 	require.NoError(t, err)
 	diff := cmp.Diff(loaded, []*Computors{{
 		Epoch:     123,
@@ -110,7 +110,7 @@ func TestGet_ExistingList_SameSignature_NoFetch(t *testing.T) {
 		Signature: signature,
 	}}
 
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		computors: types.Computors{
 			Epoch:     123,
 			PubKeys:   [NumberOfComputors][32]byte{{1}, {2}, {3}},
@@ -122,9 +122,9 @@ func TestGet_ExistingList_SameSignature_NoFetch(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pass matching signature package - should NOT fetch from node
-	loaded, err := Get(context.Background(), dataStore, client, 100, 0, 42, signaturePackage)
+	loaded, err := Get(context.Background(), dataStore, fetcher, 100, 0, 42, signaturePackage, true)
 	require.NoError(t, err)
-	require.False(t, client.getComputorsCalled, "GetComputors should NOT be called when signature matches")
+	require.False(t, fetcher.getComputorsCalled, "GetComputors should NOT be called when signature matches")
 	require.Len(t, loaded, 1)
 }
 
@@ -147,7 +147,7 @@ func TestGet_ExistingList_NewSignature_AppendsNew(t *testing.T) {
 	newSignature := [64]byte{0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}
 	newSignaturePackage := binary.LittleEndian.Uint64(newSignature[:8])
 
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		computors: types.Computors{
 			Epoch:     123,
 			PubKeys:   [NumberOfComputors][32]byte{{4}, {5}, {6}},
@@ -159,9 +159,9 @@ func TestGet_ExistingList_NewSignature_AppendsNew(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pass different signature package - should fetch from node and append
-	loaded, err := Get(context.Background(), dataStore, client, 100, 0, 42, newSignaturePackage)
+	loaded, err := Get(context.Background(), dataStore, fetcher, 100, 0, 42, newSignaturePackage, true)
 	require.NoError(t, err)
-	require.True(t, client.getComputorsCalled, "GetComputors should be called when signature differs")
+	require.True(t, fetcher.getComputorsCalled, "GetComputors should be called when signature differs")
 	require.Len(t, loaded, 2)
 	require.Equal(t, uint32(100), loaded[1].TickNumber, "New computors should have the provided tick number")
 	require.Equal(t, newSignature, loaded[1].Signature)
@@ -175,7 +175,7 @@ func TestGet_EmptyStore_SignatureMismatch_Errors(t *testing.T) {
 	// Node returns computors with this signature
 	nodeSignature := [64]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		computors: types.Computors{
 			Epoch:     123,
 			PubKeys:   [NumberOfComputors][32]byte{{1}, {2}, {3}},
@@ -187,10 +187,10 @@ func TestGet_EmptyStore_SignatureMismatch_Errors(t *testing.T) {
 	differentSignaturePackage := uint64(0xDEADBEEF)
 
 	// No stored computors - will fetch from node, but signature won't match
-	_, err = Get(context.Background(), dataStore, client, 100, 50, 42, differentSignaturePackage)
+	_, err = Get(context.Background(), dataStore, fetcher, 100, 50, 42, differentSignaturePackage, true)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "initial computor list signature does not match")
-	require.True(t, client.getComputorsCalled, "GetComputors should be called for initial fetch")
+	require.True(t, fetcher.getComputorsCalled, "GetComputors should be called for initial fetch")
 }
 
 func TestGet_EmptyStore_SignatureMatch_Succeeds(t *testing.T) {
@@ -202,7 +202,7 @@ func TestGet_EmptyStore_SignatureMatch_Succeeds(t *testing.T) {
 	nodeSignature := [64]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
 	signaturePackage := binary.LittleEndian.Uint64(nodeSignature[:8])
 
-	client := &TestClient{
+	fetcher := &TestFetcher{
 		computors: types.Computors{
 			Epoch:     123,
 			PubKeys:   [NumberOfComputors][32]byte{{1}, {2}, {3}},
@@ -211,11 +211,45 @@ func TestGet_EmptyStore_SignatureMatch_Succeeds(t *testing.T) {
 	}
 
 	// No stored computors - will fetch from node, signature matches
-	loaded, err := Get(context.Background(), dataStore, client, 100, 50, 42, signaturePackage)
+	loaded, err := Get(context.Background(), dataStore, fetcher, 100, 50, 42, signaturePackage, true)
 	require.NoError(t, err)
-	require.True(t, client.getComputorsCalled)
+	require.True(t, fetcher.getComputorsCalled)
 	require.Len(t, loaded, 1)
 	require.Equal(t, uint32(50), loaded[0].TickNumber, "Initial computors should use initialTick")
+}
+
+func TestGet_BobPath_FetchesOncePerEpoch(t *testing.T) {
+	dataStore, err := createTestDataStore(t)
+	defer closeDb(dataStore)
+	require.NoError(t, err)
+
+	fetcher := &TestFetcher{
+		computors: types.Computors{
+			Epoch:     123,
+			PubKeys:   [NumberOfComputors][32]byte{{1}, {2}, {3}},
+			Signature: [64]byte{},
+		},
+	}
+
+	// First call with computorSignatureAvailable=false (bob path) - should fetch
+	loaded, err := Get(context.Background(), dataStore, fetcher, 100, 50, 42, 0, false)
+	require.NoError(t, err)
+	require.True(t, fetcher.getComputorsCalled)
+	require.Len(t, loaded, 1)
+	require.True(t, loaded[0].Validated, "Bob-sourced computors should be marked as validated")
+
+	// Save them
+	err = Save(context.Background(), dataStore, 42, loaded)
+	require.NoError(t, err)
+
+	// Reset flag
+	fetcher.getComputorsCalled = false
+
+	// Second call - should load from store, not fetch again
+	loaded, err = Get(context.Background(), dataStore, fetcher, 200, 50, 42, 0, false)
+	require.NoError(t, err)
+	require.False(t, fetcher.getComputorsCalled, "GetComputors should NOT be called when already stored (bob path)")
+	require.Len(t, loaded, 1)
 }
 
 func createTestDataStore(t *testing.T) (*db.PebbleStore, error) {
@@ -229,90 +263,41 @@ func closeDb(database *db.PebbleStore) {
 	_ = database.Close()
 }
 
-type TestClient struct {
+// TestFetcher implements network.DataFetcher for testing computors.
+type TestFetcher struct {
 	computors             types.Computors
 	getComputorsCalled    bool
 	getComputorsCallCount int
 }
 
-func (t *TestClient) GetIssuedAssets(_ context.Context, _ string) (types.IssuedAssets, error) {
-	panic("implement me")
+func (f *TestFetcher) GetTickStatus(_ context.Context) (network.TickStatus, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetPossessedAssets(_ context.Context, _ string) (types.PossessedAssets, error) {
-	panic("implement me")
+func (f *TestFetcher) GetSystemMetadata(_ context.Context) (network.SystemMetadata, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetOwnedAssets(_ context.Context, _ string) (types.OwnedAssets, error) {
-	panic("implement me")
+func (f *TestFetcher) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetIdentity(_ context.Context, _ string) (types.AddressInfo, error) {
-	panic("implement me")
+func (f *TestFetcher) GetTickData(_ context.Context, _ uint32) (types.TickData, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetTickInfo(_ context.Context) (types.TickInfo, error) {
-	panic("implement me")
+func (f *TestFetcher) GetTickTransactions(_ context.Context, _ uint32) (types.Transactions, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetSystemInfo(_ context.Context) (types.SystemInfo, error) {
-	panic("implement me")
+func (f *TestFetcher) GetComputors(_ context.Context) (types.Computors, error) {
+	f.getComputorsCalled = true
+	f.getComputorsCallCount++
+	return f.computors, nil
 }
 
-func (t *TestClient) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, error) {
-	panic("implement me")
+func (f *TestFetcher) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, bool, error) {
+	panic("not implemented")
 }
 
-func (t *TestClient) GetTickData(_ context.Context, _ uint32) (types.TickData, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetTickTransactions(_ context.Context, _ uint32) (types.Transactions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) SendRawTransaction(_ context.Context, _ []byte) error {
-	panic("implement me")
-}
-
-func (t *TestClient) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetComputors(_ context.Context) (types.Computors, error) {
-	t.getComputorsCalled = true
-	t.getComputorsCallCount++
-	return t.computors, nil
-}
-
-func (t *TestClient) QuerySmartContract(_ context.Context, _ qubic.RequestContractFunction, _ []byte) (types.SmartContractData, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetPossessionsByFilter(_ context.Context, _, _, _, _ string, _, _ uint16) (types.AssetPossessions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetOwnershipsByFilter(_ context.Context, _, _, _ string, _ uint16) (types.AssetOwnerships, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetIssuancesByFilter(_ context.Context, _, _ string) (types.AssetIssuances, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetIssuancesByUniverseIndex(_ context.Context, _ uint32) (types.AssetIssuances, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetOwnershipsByUniverseIndex(_ context.Context, _ uint32) (types.AssetOwnerships, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) GetAssetPossessionsByUniverseIndex(_ context.Context, _ uint32) (types.AssetPossessions, error) {
-	panic("implement me")
-}
-
-func (t *TestClient) Close() error {
-	panic("implement me")
-}
+func (f *TestFetcher) Release(_ error) {}

--- a/validator/quorum/validator.go
+++ b/validator/quorum/validator.go
@@ -16,12 +16,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// Validate validates the quorum votes and if success returns the aligned votes back
-func Validate(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) (types.QuorumVotes, error) {
-	return validateVotes(ctx, quorumVotes, computors, targetTickVoteSignature)
+// Validate validates the quorum votes and if success returns the aligned votes back.
+// When skipScoreCheck is true, the TargetTickVoteSignature score filter is skipped
+// but cryptographic signature verification still runs. This is used when the data
+// source (e.g. bob) does not provide the target vote signature.
+func Validate(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) (types.QuorumVotes, error) {
+	return validateVotes(ctx, quorumVotes, computors, targetTickVoteSignature, skipScoreCheck)
 }
 
-func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) (types.QuorumVotes, error) {
+func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) (types.QuorumVotes, error) {
 	if len(quorumVotes) < types.MinimumQuorumVotes {
 		return nil, errors.New("not enough quorum votes")
 	}
@@ -35,7 +38,7 @@ func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors
 		return nil, fmt.Errorf("not enough aligned votes [%d]", len(alignedVotes))
 	}
 
-	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature)
+	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature, skipScoreCheck)
 	if err != nil {
 		return nil, fmt.Errorf("verifying tick signature: %w", err)
 	}
@@ -113,14 +116,14 @@ func (v *vote) digest() ([32]byte, error) {
 	return digest, nil
 }
 
-func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) error {
+func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) error {
 	var errorGroup errgroup.Group
 	verifyChannel := make(chan int, len(quorumVotes)) // second argument is buffer capacity
 	defer close(verifyChannel)
 
 	for _, quorumTickData := range quorumVotes {
 		errorGroup.Go(func() error {
-			success, err := checkSignature(ctx, quorumTickData, computors, targetTickVoteSignature)
+			success, err := checkSignature(ctx, quorumTickData, computors, targetTickVoteSignature, skipScoreCheck)
 			if success > 0 {
 				verifyChannel <- success
 			}
@@ -140,13 +143,13 @@ func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, com
 	return nil
 }
 
-func checkSignature(ctx context.Context, quorumTickData types.QuorumTickVote, computors computors.Computors, targetTickVoteSignature uint32) (int, error) {
+func checkSignature(ctx context.Context, quorumTickData types.QuorumTickVote, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) (int, error) {
 	digest, err := getDigestFromQuorumTickData(quorumTickData)
 	if err != nil {
 		return 0, fmt.Errorf("creating digest from quorum tick data: %w", err)
 	}
 	computorPubKey := computors.PubKeys[quorumTickData.ComputorIndex]
-	if err := verifyTickVoteSignature(ctx, utils.SchnorrqVerify, computorPubKey, digest, quorumTickData.Signature, targetTickVoteSignature); err != nil {
+	if err := verifyTickVoteSignature(ctx, utils.SchnorrqVerify, computorPubKey, digest, quorumTickData.Signature, targetTickVoteSignature, skipScoreCheck); err != nil {
 		// the following is only additional debug information to identify the failing computor
 		var badComputor types.Identity
 		badComputor, ce := badComputor.FromPubKey(computorPubKey, false)
@@ -160,12 +163,14 @@ func checkSignature(ctx context.Context, quorumTickData types.QuorumTickVote, co
 	return 1, nil // success
 }
 
-func verifyTickVoteSignature(ctx context.Context, sigVerifierFunc utils.SigVerifierFunc, computorPubKey, digest [32]byte, signature [64]byte, targetTickVoteSignature uint32) error {
-	invertedSignatureSection := swapBytes(signature[:4])
-	score := binary.LittleEndian.Uint32(invertedSignatureSection)
+func verifyTickVoteSignature(ctx context.Context, sigVerifierFunc utils.SigVerifierFunc, computorPubKey, digest [32]byte, signature [64]byte, targetTickVoteSignature uint32, skipScoreCheck bool) error {
+	if !skipScoreCheck {
+		invertedSignatureSection := swapBytes(signature[:4])
+		score := binary.LittleEndian.Uint32(invertedSignatureSection)
 
-	if score > targetTickVoteSignature {
-		return errors.New("vote signature score over target tick vote signature")
+		if score > targetTickVoteSignature {
+			return errors.New("vote signature score over target tick vote signature")
+		}
 	}
 
 	return sigVerifierFunc(ctx, computorPubKey, digest, signature)

--- a/validator/quorum/validator.go
+++ b/validator/quorum/validator.go
@@ -20,13 +20,13 @@ import (
 // When skipScoreCheck is true, the TargetTickVoteSignature score filter is skipped
 // but cryptographic signature verification still runs. This is used when the data
 // source (e.g. bob) does not provide the target vote signature.
-func Validate(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) (types.QuorumVotes, error) {
-	return validateVotes(ctx, quorumVotes, computors, targetTickVoteSignature, skipScoreCheck)
+func Validate(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool, minVotes int) (types.QuorumVotes, error) {
+	return validateVotes(ctx, quorumVotes, computors, targetTickVoteSignature, skipScoreCheck, minVotes)
 }
 
-func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) (types.QuorumVotes, error) {
-	if len(quorumVotes) < types.MinimumQuorumVotes {
-		return nil, errors.New("not enough quorum votes")
+func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool, minVotes int) (types.QuorumVotes, error) {
+	if len(quorumVotes) < minVotes {
+		return nil, fmt.Errorf("not enough quorum votes: have %d, need %d", len(quorumVotes), minVotes)
 	}
 
 	alignedVotes, err := getAlignedVotes(quorumVotes)
@@ -34,11 +34,11 @@ func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors
 		return nil, fmt.Errorf("getting aligned votes: %w", err)
 	}
 
-	if len(alignedVotes) < types.MinimumQuorumVotes {
-		return nil, fmt.Errorf("not enough aligned votes [%d]", len(alignedVotes))
+	if len(alignedVotes) < minVotes {
+		return nil, fmt.Errorf("not enough aligned votes [%d], need %d", len(alignedVotes), minVotes)
 	}
 
-	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature, skipScoreCheck)
+	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature, skipScoreCheck, minVotes)
 	if err != nil {
 		return nil, fmt.Errorf("verifying tick signature: %w", err)
 	}
@@ -116,7 +116,7 @@ func (v *vote) digest() ([32]byte, error) {
 	return digest, nil
 }
 
-func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool) error {
+func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, skipScoreCheck bool, minVotes int) error {
 	var errorGroup errgroup.Group
 	verifyChannel := make(chan int, len(quorumVotes)) // second argument is buffer capacity
 	defer close(verifyChannel)
@@ -137,8 +137,8 @@ func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, com
 	}
 
 	var successVotes = len(verifyChannel)
-	if successVotes < types.MinimumQuorumVotes {
-		return fmt.Errorf("not enough verified quorum votes: %d", successVotes)
+	if successVotes < minVotes {
+		return fmt.Errorf("not enough verified quorum votes: have %d, need %d", successVotes, minVotes)
 	}
 	return nil
 }

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -63,7 +63,7 @@ func TestValidateVotes(t *testing.T) {
 		},
 	}
 
-	_, err := validateVotes(context.Background(), originalData, computors.Computors{}, 0)
+	_, err := validateVotes(context.Background(), originalData, computors.Computors{}, 0, false)
 	require.ErrorContains(t, err, "not enough quorum votes")
 
 	cases := []struct {

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -63,7 +63,7 @@ func TestValidateVotes(t *testing.T) {
 		},
 	}
 
-	_, err := validateVotes(context.Background(), originalData, computors.Computors{}, 0, false)
+	_, err := validateVotes(context.Background(), originalData, computors.Computors{}, 0, false, 451)
 	require.ErrorContains(t, err, "not enough quorum votes")
 
 	cases := []struct {

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -257,21 +257,36 @@ func deepCopy(votes types.QuorumVotes) types.QuorumVotes {
 	return cp
 }
 
-func TestValidateVotes_EmptyTick_LowerThreshold(t *testing.T) {
-	// Empty tick votes have zero TxDigest. With minVotes=2, two empty votes should pass.
+func TestValidateVotes_EmptyTick_LowerThreshold_RejectsBelow(t *testing.T) {
+	// Empty tick votes have zero TxDigest. With only 2 votes and minVotes=451, should fail.
 	emptyVotes := types.QuorumVotes{
 		{ComputorIndex: 0, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
 		{ComputorIndex: 1, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
 	}
 
-	// With minVotes=451, should fail
 	_, err := validateVotes(context.Background(), emptyVotes, computors.Computors{}, 0, true, 451)
 	require.ErrorContains(t, err, "not enough quorum votes")
+}
 
-	// With minVotes=2, should pass (aligned votes are 2, sig verify skipped via skipScoreCheck)
-	alignedVotes, err := validateVotes(context.Background(), emptyVotes, computors.Computors{}, 0, true, 2)
+func TestValidateVotes_EmptyTick_LowerThreshold_AlignmentPasses(t *testing.T) {
+	// Test that empty tick votes align correctly and pass the minVotes threshold.
+	// We test alignment only (not sig verification) since the lower threshold
+	// is about accepting fewer votes, not about signature validity.
+	emptyVotes := types.QuorumVotes{
+		{ComputorIndex: 0, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+		{ComputorIndex: 1, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+		{ComputorIndex: 2, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+	}
+
+	alignedVotes, err := getAlignedVotes(emptyVotes)
 	require.NoError(t, err)
-	require.Equal(t, 2, len(alignedVotes))
+	require.Equal(t, 3, len(alignedVotes))
+
+	// Verify that minVotes=3 would pass the threshold check
+	require.GreaterOrEqual(t, len(alignedVotes), 3)
+
+	// And minVotes=451 would not
+	require.Less(t, len(alignedVotes), 451)
 }
 
 func TestValidateVotes_EmptyTick_NotEnoughEvenForLowerThreshold(t *testing.T) {

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -257,6 +257,33 @@ func deepCopy(votes types.QuorumVotes) types.QuorumVotes {
 	return cp
 }
 
+func TestValidateVotes_EmptyTick_LowerThreshold(t *testing.T) {
+	// Empty tick votes have zero TxDigest. With minVotes=2, two empty votes should pass.
+	emptyVotes := types.QuorumVotes{
+		{ComputorIndex: 0, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+		{ComputorIndex: 1, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+	}
+
+	// With minVotes=451, should fail
+	_, err := validateVotes(context.Background(), emptyVotes, computors.Computors{}, 0, true, 451)
+	require.ErrorContains(t, err, "not enough quorum votes")
+
+	// With minVotes=2, should pass (aligned votes are 2, sig verify skipped via skipScoreCheck)
+	alignedVotes, err := validateVotes(context.Background(), emptyVotes, computors.Computors{}, 0, true, 2)
+	require.NoError(t, err)
+	require.Equal(t, 2, len(alignedVotes))
+}
+
+func TestValidateVotes_EmptyTick_NotEnoughEvenForLowerThreshold(t *testing.T) {
+	emptyVotes := types.QuorumVotes{
+		{ComputorIndex: 0, Epoch: 1, Tick: 100, TxDigest: [32]byte{}},
+	}
+
+	// Even with lower threshold of 2, 1 vote is not enough
+	_, err := validateVotes(context.Background(), emptyVotes, computors.Computors{}, 0, true, 2)
+	require.ErrorContains(t, err, "not enough quorum votes")
+}
+
 func TestByteSwap(t *testing.T) {
 
 	testData := []struct {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -46,8 +46,15 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, fetcher
 		if len(quorumVotes) <= 0 {
 			return errors.New("no quorum votes fetched")
 		}
-		if len(quorumVotes) < 451 {
-			return fmt.Errorf("not enough quorum votes yet: [%d]", len(quorumVotes))
+		// For empty ticks (all votes have zero TxDigest), a lower threshold is
+		// acceptable — during catchup bob may only receive partial votes for
+		// empty ticks. One-third of computors is sufficient for empty consensus.
+		minRequired := types.MinimumQuorumVotes // 451
+		if allVotesEmpty(quorumVotes) {
+			minRequired = types.NumberOfComputors / 3 // 225
+		}
+		if len(quorumVotes) < minRequired {
+			return fmt.Errorf("not enough quorum votes yet: [%d] (min: %d)", len(quorumVotes), minRequired)
 		}
 		return nil
 	})
@@ -74,7 +81,11 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, fetcher
 	}
 
 	skipScoreCheck := !systemMeta.VoteSignatureAvailable
-	alignedVotes, err := quorum.Validate(ctx, quorumVotes, comps, systemMeta.TargetTickVoteSignature, skipScoreCheck) // fast
+	minVotes := types.MinimumQuorumVotes
+	if allVotesEmpty(quorumVotes) {
+		minVotes = types.NumberOfComputors / 3
+	}
+	alignedVotes, err := quorum.Validate(ctx, quorumVotes, comps, systemMeta.TargetTickVoteSignature, skipScoreCheck, minVotes)
 	if err != nil {
 		return fmt.Errorf("validating quorum votes: %w", err)
 	}
@@ -247,4 +258,14 @@ func (v *Validator) validateTransactions(ctx context.Context, fetcher network.Da
 
 func isEmptyTick(quorumVotes types.QuorumVotes) bool {
 	return quorumVotes[0].TxDigest == [32]byte{}
+}
+
+// allVotesEmpty returns true if every vote has a zero TxDigest, indicating an empty tick.
+func allVotesEmpty(votes types.QuorumVotes) bool {
+	for _, v := range votes {
+		if v.TxDigest != [32]byte{} {
+			return false
+		}
+	}
+	return true
 }

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -31,12 +31,7 @@ func NewValidator(arbitratorPubKey [32]byte, enableStatusAddon bool) *Validator 
 	}
 }
 
-type Clients struct {
-	Main network.QubicClient
-	Alt  network.QubicClient
-}
-
-func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients Clients, epoch uint16, tickNumber uint32) error {
+func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, fetcher network.DataFetcher, epoch uint16, tickNumber uint32) error {
 
 	var quorumVotes types.QuorumVotes
 
@@ -44,7 +39,7 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 	eg.Go(func() error {
 		// validate quorum
 		var err error
-		quorumVotes, err = clients.Main.GetQuorumVotes(egCtx, tickNumber)
+		quorumVotes, err = fetcher.GetQuorumVotes(egCtx, tickNumber)
 		if err != nil {
 			return fmt.Errorf("getting quorum votes: %w", err)
 		}
@@ -57,35 +52,36 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 		return nil
 	})
 
-	var systemInfo types.SystemInfo
+	var systemMeta network.SystemMetadata
 	eg.Go(func() error {
 		var err error
-		systemInfo, err = clients.Alt.GetSystemInfo(egCtx)
+		systemMeta, err = fetcher.GetSystemMetadata(egCtx)
 		if err != nil {
-			return fmt.Errorf("getting system info: %w", err)
+			return fmt.Errorf("getting system metadata: %w", err)
 		}
 		return nil
 	})
 
 	err := eg.Wait()
 	if err != nil {
-		return fmt.Errorf("getting quorum votes and/or system info: %w", err)
+		return fmt.Errorf("getting quorum votes and/or system metadata: %w", err)
 	}
 
 	// typically only one client call needed per epoch
-	comps, err := v.validateComputors(ctx, store, clients.Main, tickNumber, systemInfo.InitialTick, epoch, systemInfo.ComputorPacketSignature)
+	comps, err := v.validateComputors(ctx, store, fetcher, tickNumber, systemMeta.InitialTick, epoch, systemMeta.ComputorPacketSignature, systemMeta.ComputorSignatureAvailable)
 	if err != nil {
 		return fmt.Errorf("validating computors: %w", err)
 	}
 
-	alignedVotes, err := quorum.Validate(ctx, quorumVotes, comps, systemInfo.TargetTickVoteSignature) // fast
+	skipScoreCheck := !systemMeta.VoteSignatureAvailable
+	alignedVotes, err := quorum.Validate(ctx, quorumVotes, comps, systemMeta.TargetTickVoteSignature, skipScoreCheck) // fast
 	if err != nil {
 		return fmt.Errorf("validating quorum votes: %w", err)
 	}
 	log.Printf("Quorum valid. Aligned %d. Misaligned %d.", len(alignedVotes), len(quorumVotes)-len(alignedVotes))
 
 	// validate tick data and transactions
-	tickData, validTxs, txStatus, err := v.validateTickDataAndTransactions(ctx, alignedVotes, clients, comps, tickNumber)
+	tickData, validTxs, txStatus, err := v.validateTickDataAndTransactions(ctx, alignedVotes, fetcher, comps, tickNumber)
 	if err != nil {
 		return fmt.Errorf("validating tick data and transactions: %w", err)
 	}
@@ -97,9 +93,11 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 		return fmt.Errorf("storing aligned quorum votes: %w", err)
 	}
 
-	err = quorum.StoreTargetTickVoteSignature(store, uint32(epoch), tickNumber, systemInfo.InitialTick, systemInfo.TargetTickVoteSignature)
-	if err != nil {
-		return fmt.Errorf("storing target tick signature: %w", err)
+	if systemMeta.VoteSignatureAvailable {
+		err = quorum.StoreTargetTickVoteSignature(store, uint32(epoch), tickNumber, systemMeta.InitialTick, systemMeta.TargetTickVoteSignature)
+		if err != nil {
+			return fmt.Errorf("storing target tick signature: %w", err)
+		}
 	}
 
 	err = tick.Store(ctx, store, tickNumber, tickData)
@@ -120,7 +118,7 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 	return nil
 }
 
-func (v *Validator) validateTickDataAndTransactions(ctx context.Context, alignedVotes types.QuorumVotes, clients Clients, comps computors.Computors, tickNumber uint32) (tickData types.TickData, validTxs []types.Transaction, txStatus *protobuf.TickTransactionsStatus, err error) {
+func (v *Validator) validateTickDataAndTransactions(ctx context.Context, alignedVotes types.QuorumVotes, fetcher network.DataFetcher, comps computors.Computors, tickNumber uint32) (tickData types.TickData, validTxs []types.Transaction, txStatus *protobuf.TickTransactionsStatus, err error) {
 
 	if isEmptyTick(alignedVotes) {
 		return types.TickData{}, make([]types.Transaction, 0), &protobuf.TickTransactionsStatus{}, nil
@@ -130,7 +128,7 @@ func (v *Validator) validateTickDataAndTransactions(ctx context.Context, aligned
 
 	eg.Go(func() error {
 		var err error
-		tickData, err = v.validateTickData(egCtx, clients.Alt, comps, alignedVotes, tickNumber)
+		tickData, err = v.validateTickData(egCtx, fetcher, comps, alignedVotes, tickNumber)
 		if err != nil {
 			return fmt.Errorf("getting tick data: %w", err)
 		}
@@ -140,7 +138,7 @@ func (v *Validator) validateTickDataAndTransactions(ctx context.Context, aligned
 	var transactions []types.Transaction
 	eg.Go(func() error {
 		var err error
-		transactions, err = clients.Main.GetTickTransactions(egCtx, tickNumber)
+		transactions, err = fetcher.GetTickTransactions(egCtx, tickNumber)
 		if err != nil {
 			return fmt.Errorf("getting transactions: %w", err)
 		}
@@ -152,7 +150,7 @@ func (v *Validator) validateTickDataAndTransactions(ctx context.Context, aligned
 		return tickData, nil, nil, fmt.Errorf("getting tick data and/or transactions: %w", err)
 	}
 
-	validTxs, txStatus, err = v.validateTransactions(ctx, clients.Main, transactions, tickData, tickNumber)
+	validTxs, txStatus, err = v.validateTransactions(ctx, fetcher, transactions, tickData, tickNumber)
 	if err != nil {
 		return tickData, nil, nil, fmt.Errorf("validating transactions: %w", err)
 	}
@@ -161,9 +159,9 @@ func (v *Validator) validateTickDataAndTransactions(ctx context.Context, aligned
 
 }
 
-func (v *Validator) validateComputors(ctx context.Context, store *db.PebbleStore, client network.QubicClient, tickNumber, initialTick uint32, epoch uint16, computorPacketSignature uint64) (computors.Computors, error) {
+func (v *Validator) validateComputors(ctx context.Context, store *db.PebbleStore, fetcher network.DataFetcher, tickNumber, initialTick uint32, epoch uint16, computorPacketSignature uint64, computorSignatureAvailable bool) (computors.Computors, error) {
 
-	comps, err := computors.Get(ctx, store, client, tickNumber, initialTick, epoch, computorPacketSignature)
+	comps, err := computors.Get(ctx, store, fetcher, tickNumber, initialTick, epoch, computorPacketSignature, computorSignatureAvailable)
 	if err != nil {
 		return computors.Computors{}, fmt.Errorf("getting computors: %w", err)
 	}
@@ -173,9 +171,11 @@ func (v *Validator) validateComputors(ctx context.Context, store *db.PebbleStore
 
 	latestComps := comps[len(comps)-1]
 	if !latestComps.Validated || bytes.Compare(v.arbitratorPubKey[:], latestComps.Arbitrator[:]) != 0 {
-		err = computors.Validate(ctx, *latestComps, v.arbitratorPubKey)
-		if err != nil {
-			return computors.Computors{}, fmt.Errorf("validating computors: %w", err)
+		if computorSignatureAvailable {
+			err = computors.Validate(ctx, *latestComps, v.arbitratorPubKey)
+			if err != nil {
+				return computors.Computors{}, fmt.Errorf("validating computors: %w", err)
+			}
 		}
 		latestComps.Validated = true
 		latestComps.Arbitrator = v.arbitratorPubKey
@@ -189,8 +189,8 @@ func (v *Validator) validateComputors(ctx context.Context, store *db.PebbleStore
 	return *latestComps, nil
 }
 
-func (v *Validator) validateTickData(ctx context.Context, client network.QubicClient, comps computors.Computors, quorumVotes types.QuorumVotes, tickNumber uint32) (types.TickData, error) {
-	tickData, err := client.GetTickData(ctx, tickNumber)
+func (v *Validator) validateTickData(ctx context.Context, fetcher network.DataFetcher, comps computors.Computors, quorumVotes types.QuorumVotes, tickNumber uint32) (types.TickData, error) {
+	tickData, err := fetcher.GetTickData(ctx, tickNumber)
 	if err != nil {
 		return types.TickData{}, fmt.Errorf("getting tick data: %w", err)
 	}
@@ -203,7 +203,7 @@ func (v *Validator) validateTickData(ctx context.Context, client network.QubicCl
 	return tickData, nil
 }
 
-func (v *Validator) validateTransactions(ctx context.Context, client network.QubicClient, transactions []types.Transaction, tickData types.TickData, tickNumber uint32) ([]types.Transaction, *protobuf.TickTransactionsStatus, error) {
+func (v *Validator) validateTransactions(ctx context.Context, fetcher network.DataFetcher, transactions []types.Transaction, tickData types.TickData, tickNumber uint32) ([]types.Transaction, *protobuf.TickTransactionsStatus, error) {
 
 	// keeps all transactions that are in the tick data digests
 	validTxs, err := tx.Validate(ctx, transactions, tickData)
@@ -217,35 +217,32 @@ func (v *Validator) validateTransactions(ctx context.Context, client network.Qub
 		log.Printf("[%d] out of [%d] transactions are valid.", len(validTxs), len(transactions))
 	}
 
-	// get tx status only if status addon is enabled
-	tickTxStatus, err := getTxStatus(ctx, client, len(validTxs), tickNumber, v.statusAddonEnabled)
+	// get tx status
+	tickTxStatus, txStatusAvailable, err := fetcher.GetTxStatus(ctx, tickNumber)
 	if err != nil {
 		return nil, nil, fmt.Errorf("getting tx status: %w", err)
 	}
 
+	shouldValidateStatus := txStatusAvailable && v.statusAddonEnabled
+	if !txStatusAvailable {
+		// fill in stub data when status is not available (e.g. bob backend)
+		tickTxStatus = types.TransactionStatus{
+			CurrentTickOfNode:  tickNumber,
+			Tick:               tickNumber,
+			TxCount:            uint32(len(validTxs)),
+			MoneyFlew:          [128]byte{},
+			TransactionDigests: nil,
+		}
+	}
+
 	// combine valid transactions with money flew status
-	transactionsWithTxStatus, err := txstatus.ValidateAndConvert(ctx, tickTxStatus, validTxs, v.statusAddonEnabled)
+	transactionsWithTxStatus, err := txstatus.ValidateAndConvert(ctx, tickTxStatus, validTxs, shouldValidateStatus)
 	if err != nil {
 		return nil, nil, fmt.Errorf("validating tx status: %w", err)
 	}
 
 	return validTxs, transactionsWithTxStatus, nil
 
-}
-
-func getTxStatus(ctx context.Context, client network.QubicClient, transactionsCount int, tickNumber uint32, enabled bool) (types.TransactionStatus, error) {
-	if enabled {
-		return client.GetTxStatus(ctx, tickNumber)
-	} else {
-		// empty transaction status
-		return types.TransactionStatus{
-			CurrentTickOfNode:  tickNumber,
-			Tick:               tickNumber,
-			TxCount:            uint32(transactionsCount),
-			MoneyFlew:          [128]byte{},
-			TransactionDigests: nil,
-		}, nil
-	}
 }
 
 func isEmptyTick(quorumVotes types.QuorumVotes) bool {

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -5,92 +5,57 @@ import (
 	"errors"
 	"testing"
 
-	qubic "github.com/qubic/go-node-connector"
-	"github.com/qubic/go-node-connector/types"
-	"github.com/stretchr/testify/require"
-
+	"github.com/qubic/go-archiver-v2/network"
 	"github.com/qubic/go-archiver-v2/protobuf"
 	"github.com/qubic/go-archiver-v2/validator/computors"
+	"github.com/qubic/go-node-connector/types"
+	"github.com/stretchr/testify/require"
 )
 
-// stubClient implements network.QubicClient with configurable behaviour for the methods exercised
-// by the validator. Any method that is not configured panics, acting as a strict expectation that
-// it must not be called.
-type stubClient struct {
-	getTxStatusErr        error
+// stubFetcher implements network.DataFetcher with configurable behaviour for the methods
+// exercised by the validator. Any method that is not configured panics, acting as a strict
+// expectation that it must not be called.
+type stubFetcher struct {
 	getTickDataFn         func(ctx context.Context, tickNumber uint32) (types.TickData, error)
 	getTickTransactionsFn func(ctx context.Context, tickNumber uint32) (types.Transactions, error)
+	getTxStatusErr        error
 }
 
-func (s *stubClient) GetTxStatus(context.Context, uint32) (types.TransactionStatus, error) {
-	return types.TransactionStatus{}, s.getTxStatusErr
+func (s *stubFetcher) GetTickStatus(_ context.Context) (network.TickStatus, error) {
+	panic("unexpected call to GetTickStatus")
 }
 
-func (s *stubClient) GetTickData(ctx context.Context, tickNumber uint32) (types.TickData, error) {
+func (s *stubFetcher) GetSystemMetadata(_ context.Context) (network.SystemMetadata, error) {
+	panic("unexpected call to GetSystemMetadata")
+}
+
+func (s *stubFetcher) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
+	panic("unexpected call to GetQuorumVotes")
+}
+
+func (s *stubFetcher) GetTickData(ctx context.Context, tickNumber uint32) (types.TickData, error) {
 	if s.getTickDataFn == nil {
 		panic("unexpected call to GetTickData")
 	}
 	return s.getTickDataFn(ctx, tickNumber)
 }
 
-func (s *stubClient) GetTickTransactions(ctx context.Context, tickNumber uint32) (types.Transactions, error) {
+func (s *stubFetcher) GetTickTransactions(ctx context.Context, tickNumber uint32) (types.Transactions, error) {
 	if s.getTickTransactionsFn == nil {
 		panic("unexpected call to GetTickTransactions")
 	}
 	return s.getTickTransactionsFn(ctx, tickNumber)
 }
 
-func (s *stubClient) GetIssuedAssets(_ context.Context, _ string) (types.IssuedAssets, error) {
-	panic("not implemented")
+func (s *stubFetcher) GetComputors(_ context.Context) (types.Computors, error) {
+	panic("unexpected call to GetComputors")
 }
-func (s *stubClient) GetPossessedAssets(_ context.Context, _ string) (types.PossessedAssets, error) {
-	panic("not implemented")
+
+func (s *stubFetcher) GetTxStatus(_ context.Context, _ uint32) (types.TransactionStatus, bool, error) {
+	return types.TransactionStatus{}, true, s.getTxStatusErr
 }
-func (s *stubClient) GetOwnedAssets(_ context.Context, _ string) (types.OwnedAssets, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetIdentity(_ context.Context, _ string) (types.AddressInfo, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetTickInfo(_ context.Context) (types.TickInfo, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetSystemInfo(_ context.Context) (types.SystemInfo, error) {
-	panic("not implemented")
-}
-func (s *stubClient) SendRawTransaction(_ context.Context, _ []byte) error {
-	panic("not implemented")
-}
-func (s *stubClient) GetQuorumVotes(_ context.Context, _ uint32) (types.QuorumVotes, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetComputors(_ context.Context) (types.Computors, error) {
-	panic("not implemented")
-}
-func (s *stubClient) QuerySmartContract(_ context.Context, _ qubic.RequestContractFunction, _ []byte) (types.SmartContractData, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetPossessionsByFilter(_ context.Context, _, _, _, _ string, _, _ uint16) (types.AssetPossessions, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetOwnershipsByFilter(_ context.Context, _, _, _ string, _ uint16) (types.AssetOwnerships, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetIssuancesByFilter(_ context.Context, _, _ string) (types.AssetIssuances, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetIssuancesByUniverseIndex(_ context.Context, _ uint32) (types.AssetIssuances, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetOwnershipsByUniverseIndex(_ context.Context, _ uint32) (types.AssetOwnerships, error) {
-	panic("not implemented")
-}
-func (s *stubClient) GetAssetPossessionsByUniverseIndex(_ context.Context, _ uint32) (types.AssetPossessions, error) {
-	panic("not implemented")
-}
-func (s *stubClient) Close() error {
-	panic("not implemented")
-}
+
+func (s *stubFetcher) Release(_ error) {}
 
 func TestValidateTickDataAndTransactions_EmptyTick(t *testing.T) {
 	// When the quorum vote has a zero TxDigest the tick is considered empty and the function
@@ -100,7 +65,7 @@ func TestValidateTickDataAndTransactions_EmptyTick(t *testing.T) {
 	emptyVotes := types.QuorumVotes{{TxDigest: [32]byte{}}}
 
 	gotTickData, gotTxs, gotStatus, err := v.validateTickDataAndTransactions(
-		context.Background(), emptyVotes, Clients{}, computors.Computors{}, 100,
+		context.Background(), emptyVotes, &stubFetcher{}, computors.Computors{}, 100,
 	)
 	require.NoError(t, err)
 	require.Equal(t, types.TickData{}, gotTickData)
@@ -116,19 +81,17 @@ func TestValidateTickDataAndTransactions_GetTickTransactionsError(t *testing.T) 
 
 	// both goroutines use the same error group so we do not care which one errors first
 	wantErr := errors.New("network error")
-	mainClient := &stubClient{
+	fetcher := &stubFetcher{
 		getTickTransactionsFn: func(_ context.Context, _ uint32) (types.Transactions, error) {
 			return nil, wantErr
 		},
-	}
-	altClient := &stubClient{
 		getTickDataFn: func(_ context.Context, _ uint32) (types.TickData, error) {
 			return types.TickData{}, wantErr
 		},
 	}
 
 	_, _, _, err := v.validateTickDataAndTransactions(
-		context.Background(), nonEmptyVotes, Clients{Main: mainClient, Alt: altClient}, computors.Computors{}, 100,
+		context.Background(), nonEmptyVotes, fetcher, computors.Computors{}, 100,
 	)
 	require.ErrorIs(t, err, wantErr)
 }
@@ -140,31 +103,29 @@ func TestValidateTickDataAndTransactions_GetTickDataError(t *testing.T) {
 
 	// both goroutines use the same error group so we do not care which one errors first
 	wantErr := errors.New("timeout")
-	mainClient := &stubClient{
+	fetcher := &stubFetcher{
 		getTickTransactionsFn: func(_ context.Context, _ uint32) (types.Transactions, error) {
 			return nil, wantErr
 		},
-	}
-	altClient := &stubClient{
 		getTickDataFn: func(_ context.Context, _ uint32) (types.TickData, error) {
 			return types.TickData{}, wantErr
 		},
 	}
 
 	_, _, _, err := v.validateTickDataAndTransactions(
-		context.Background(), nonEmptyVotes, Clients{Main: mainClient, Alt: altClient}, computors.Computors{}, 100,
+		context.Background(), nonEmptyVotes, fetcher, computors.Computors{}, 100,
 	)
 	require.ErrorIs(t, err, wantErr)
 }
 
 func TestValidateTransactions_StatusAddonEnabled_GetTxStatusError(t *testing.T) {
 	wantErr := errors.New("connection refused")
-	client := &stubClient{getTxStatusErr: wantErr}
+	fetcher := &stubFetcher{getTxStatusErr: wantErr}
 
 	v := NewValidator([32]byte{}, true)
 
 	// Empty tickData has no non-zero TransactionDigests, so tx.Validate returns [] immediately,
 	// allowing the test to reach the getTxStatus call.
-	_, _, err := v.validateTransactions(context.Background(), client, nil, types.TickData{}, 100)
+	_, _, err := v.validateTransactions(context.Background(), fetcher, nil, types.TickData{}, 100)
 	require.ErrorIs(t, err, wantErr)
 }

--- a/validator/validator_test.go
+++ b/validator/validator_test.go
@@ -129,3 +129,33 @@ func TestValidateTransactions_StatusAddonEnabled_GetTxStatusError(t *testing.T) 
 	_, _, err := v.validateTransactions(context.Background(), fetcher, nil, types.TickData{}, 100)
 	require.ErrorIs(t, err, wantErr)
 }
+
+func TestAllVotesEmpty_AllZero(t *testing.T) {
+	votes := types.QuorumVotes{
+		{TxDigest: [32]byte{}},
+		{TxDigest: [32]byte{}},
+		{TxDigest: [32]byte{}},
+	}
+	require.True(t, allVotesEmpty(votes))
+}
+
+func TestAllVotesEmpty_OneNonZero(t *testing.T) {
+	votes := types.QuorumVotes{
+		{TxDigest: [32]byte{}},
+		{TxDigest: [32]byte{1}},
+		{TxDigest: [32]byte{}},
+	}
+	require.False(t, allVotesEmpty(votes))
+}
+
+func TestAllVotesEmpty_AllNonZero(t *testing.T) {
+	votes := types.QuorumVotes{
+		{TxDigest: [32]byte{1}},
+		{TxDigest: [32]byte{2}},
+	}
+	require.False(t, allVotesEmpty(votes))
+}
+
+func TestAllVotesEmpty_EmptySlice(t *testing.T) {
+	require.True(t, allVotesEmpty(types.QuorumVotes{}))
+}


### PR DESCRIPTION
## Summary

- Introduce a `DataFetcher` interface that decouples the processing pipeline from `go-node-connector`, enabling both Qubic core nodes and bob (JSON-RPC indexer) as data sources
- Add `BobDataFetcher` implementation fetching from bob's REST and JSON-RPC API
- Refactor processor and validator to use `DataFetcher` instead of `QubicClient`
- Compute `moneyFlew` from bob's `executed` flag (bob 1.4.0+) with zero extra HTTP calls
- Handle empty ticks with lower quorum threshold (225 vs 451) for bob catchup scenarios
- Backend selected via config: `BACKEND_TYPE=node|bob`, `BACKEND_BOBURL=http://host:40420`

## Production Readiness Checklist

The following items must be resolved before the bob backend can be used in production with full data integrity guarantees. Each requires changes on the bob side first, then implementation on our side.

### High Priority

- [ ] **Epoch transition handling** — The archiver currently relies on `GetTickStatus` returning the live epoch's `InitialTick` to detect transitions. With bob, if the archiver is catching up epoch 207 but bob reports epoch 209 as current, it would skip epoch 208 entirely. **Needs**:
  - Bob to expose a list of available epochs (or the archiver probes `qubic_getEpochInfo(N)` incrementally — `initialTick: 0` means epoch not stored)
  - For each epoch bob has: `initialTick` and `endTick` (already available via `qubic_getEpochInfo`)
  - The archiver must process epochs sequentially: finish all ticks up to `endTick` of epoch N before moving to `initialTick` of epoch N+1
  - Handle the case where bob transitions to a new epoch while the archiver is still syncing the previous one (the archiver should finish the old epoch first using the known `endTick`, then start the new epoch)

- [ ] **Computor list signature** — Bob's `qubic_getComputors` returns identity strings but NOT the raw 64-byte arbitrator signature. Without this, we skip arbitrator signature validation and trust bob's computor list blindly. A compromised bob could serve fake computor keys, bypassing all quorum signature verification. **Bob needs to**: expose the `Signature` field (64 bytes, hex) in `qubic_getComputors`.

- [ ] **Data gap handling** — Bob may have gaps in historical tick data (0 votes, epoch=0). The archiver currently gets stuck on these ticks. Need to detect and skip ticks where bob has no data.

### Medium Priority

- [ ] **ComputorPacketSignature** — Bob doesn't expose `SystemInfo.ComputorPacketSignature` (uint64). Without this, the archiver fetches the computor list once per epoch and cannot detect mid-epoch changes. If computors change mid-epoch, the archiver may validate against stale keys. **Bob needs to**: expose `ComputorPacketSignature` in `/status` or `qubic_syncing`.

### Low Priority

- [ ] **TargetTickVoteSignature** — Bob doesn't expose `SystemInfo.TargetTickVoteSignature` (uint32). Without this, we skip the vote signature score filter (but still verify cryptographic signatures). Also affects per-epoch signature history storage. **Bob needs to**: expose `TargetTickVoteSignature` in `/status` or `GET /tick/{tick}`.

## What IS validated with bob backend

- Quorum vote cryptographic signatures (Schnorr verification against computor public keys)
- Quorum vote alignment (consensus detection)
- Tick data signature (computor signature on tick state)
- Transaction signatures (Schnorr verification)
- Transaction digest matching against tick data
- moneyFlew via bob's authoritative `executed` flag (bob 1.4.0+)

## Test plan

- [x] All existing tests pass (`go test ./...`)
- [x] Bob conversion tests (hex, identity roundtrip, vote/tick/tx conversion)
- [x] MoneyFlew computation tests (executed, not executed, pending, empty tick, mixed)
- [x] Empty tick lower quorum threshold tests
- [ ] Integration test with running bob instance
- [ ] Run `scripts/compare-archivers.sh` to verify tick data + moneyFlew parity
- [ ] Multi-epoch catchup test (process across epoch boundary)