### PR TITLE
Add logic related to empty tick quorum votes

### DIFF
--- a/.github/workflows/push-docker-custom.yaml
+++ b/.github/workflows/push-docker-custom.yaml
@@ -3,7 +3,7 @@ name: Deploy prod images to GHCR
 on:
   push:
     branches:
-      - 'fix/tx-status-validation'
+      - '23-empty-ticks-validation-bug'
 
 jobs:
   push-store-image:
@@ -21,5 +21,5 @@ jobs:
 
       - name: 'Build Inventory Image'
         run: |
-          docker build . --tag ghcr.io/qubic/qubic-archiver-v2:snapshot
-          docker push ghcr.io/qubic/qubic-archiver-v2:snapshot
+          docker build . --tag ghcr.io/qubic/qubic-archiver-v2:23-empty-ticks-validation-bug
+          docker push ghcr.io/qubic/qubic-archiver-v2:23-empty-ticks-validation-bug

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/qubic/go-archiver-v2
 
 go 1.25.0
 
-toolchain go1.25.5
 
 require (
 	github.com/ardanlabs/conf/v3 v3.9.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/qubic/go-archiver-v2
 
 go 1.25.0
 
+toolchain go1.25.5
+
 require (
 	github.com/ardanlabs/conf/v3 v3.9.0
 	github.com/cloudflare/circl v1.6.1

--- a/validator/quorum/validator.go
+++ b/validator/quorum/validator.go
@@ -33,12 +33,7 @@ func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors
 		return nil, fmt.Errorf("getting aligned votes: %w", err)
 	}
 
-	isEmptyTick := IsEmptyTick(alignedVotes)
-	minRequired := types.MinimumQuorumVotes
-	if isEmptyTick {
-		minRequired = EmptyTickMinVoteCount
-	}
-
+	minRequired := requiredQuorumVotes(IsEmptyTick(alignedVotes))
 	if len(alignedVotes) < minRequired {
 		return nil, fmt.Errorf("not enough aligned votes [%d], required [%d]", len(alignedVotes), minRequired)
 	}
@@ -272,4 +267,11 @@ func initTargetTickVoteSignatureList(store *db.PebbleStore, epoch, initialTick, 
 // IsEmptyTick must be called with a non-empty aligned vote set, otherwise it will panic.
 func IsEmptyTick(quorumVotes types.QuorumVotes) bool {
 	return quorumVotes[0].TxDigest == [32]byte{}
+}
+
+func requiredQuorumVotes(isEmptyTick bool) int {
+	if isEmptyTick {
+		return EmptyTickMinVoteCount
+	}
+	return types.MinimumQuorumVotes
 }

--- a/validator/quorum/validator.go
+++ b/validator/quorum/validator.go
@@ -16,13 +16,15 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const EmptyTickMinVoteCount = 226
+
 // Validate validates the quorum votes and if success returns the aligned votes back
 func Validate(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) (types.QuorumVotes, error) {
 	return validateVotes(ctx, quorumVotes, computors, targetTickVoteSignature)
 }
 
 func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) (types.QuorumVotes, error) {
-	if len(quorumVotes) < types.MinimumQuorumVotes {
+	if len(quorumVotes) < EmptyTickMinVoteCount {
 		return nil, errors.New("not enough quorum votes")
 	}
 
@@ -31,11 +33,17 @@ func validateVotes(ctx context.Context, quorumVotes types.QuorumVotes, computors
 		return nil, fmt.Errorf("getting aligned votes: %w", err)
 	}
 
-	if len(alignedVotes) < types.MinimumQuorumVotes {
-		return nil, fmt.Errorf("not enough aligned votes [%d]", len(alignedVotes))
+	isEmptyTick := IsEmptyTick(alignedVotes)
+	minRequired := types.MinimumQuorumVotes
+	if isEmptyTick {
+		minRequired = EmptyTickMinVoteCount
 	}
 
-	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature)
+	if len(alignedVotes) < minRequired {
+		return nil, fmt.Errorf("not enough aligned votes [%d], required [%d]", len(alignedVotes), minRequired)
+	}
+
+	err = quorumTickSigVerify(ctx, alignedVotes, computors, targetTickVoteSignature, minRequired)
 	if err != nil {
 		return nil, fmt.Errorf("verifying tick signature: %w", err)
 	}
@@ -113,7 +121,7 @@ func (v *vote) digest() ([32]byte, error) {
 	return digest, nil
 }
 
-func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32) error {
+func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, computors computors.Computors, targetTickVoteSignature uint32, minVotesRequired int) error {
 	var errorGroup errgroup.Group
 	verifyChannel := make(chan int, len(quorumVotes)) // second argument is buffer capacity
 	defer close(verifyChannel)
@@ -134,7 +142,7 @@ func quorumTickSigVerify(ctx context.Context, quorumVotes types.QuorumVotes, com
 	}
 
 	var successVotes = len(verifyChannel)
-	if successVotes < types.MinimumQuorumVotes {
+	if successVotes < minVotesRequired {
 		return fmt.Errorf("not enough verified quorum votes: %d", successVotes)
 	}
 	return nil
@@ -259,4 +267,9 @@ func initTargetTickVoteSignatureList(store *db.PebbleStore, epoch, initialTick, 
 	}
 	log.Printf("Initialized target vote tick signature list for epoch %d: %d\n", epoch, targetTickVoteSignature)
 	return nil
+}
+
+// IsEmptyTick must be called with a non-empty aligned vote set, otherwise it will panic.
+func IsEmptyTick(quorumVotes types.QuorumVotes) bool {
+	return quorumVotes[0].TxDigest == [32]byte{}
 }

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -284,6 +284,12 @@ func buildAlignedVotes(count int, txDigest [32]byte) types.QuorumVotes {
 	return votes
 }
 
+func TestRequiredQuorumVotes(t *testing.T) {
+	// Empty ticks need only the relaxed threshold; non-empty ticks need full BFT quorum.
+	require.Equal(t, EmptyTickMinVoteCount, requiredQuorumVotes(true))
+	require.Equal(t, types.MinimumQuorumVotes, requiredQuorumVotes(false))
+}
+
 func TestValidateVotes_BelowFloor(t *testing.T) {
 	// 225 votes is below the 226-vote floor and must be rejected before alignment runs.
 	votes := buildAlignedVotes(EmptyTickMinVoteCount-1, [32]byte{})
@@ -292,28 +298,15 @@ func TestValidateVotes_BelowFloor(t *testing.T) {
 	require.ErrorContains(t, err, "not enough quorum votes")
 }
 
-func TestValidateVotes_EmptyTick_PassesCountGateAtFloor(t *testing.T) {
-	// Exactly 226 aligned empty-tick votes must clear both the floor and the post-alignment
-	// count check. Sig verification then fails (zero pubkeys/signatures), which is what we
-	// assert on to prove the count gates were passed.
+func TestValidateVotes_EmptyTick_BelowAlignmentThreshold(t *testing.T) {
+	// 226 empty-tick votes total but one is misaligned, so only 225 align — one below
+	// the relaxed empty-tick threshold. Must be rejected at the post-alignment count gate.
 	votes := buildAlignedVotes(EmptyTickMinVoteCount, [32]byte{})
+	votes[0].Second += 1 // breaks alignment for this vote only
 
 	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "not enough quorum votes")
-	require.NotContains(t, err.Error(), "not enough aligned votes")
-	require.Contains(t, err.Error(), "verifying tick signature")
-}
-
-func TestValidateVotes_EmptyTick_PassesCountGateBetweenThresholds(t *testing.T) {
-	// 300 aligned empty-tick votes — the previously broken case. Must pass the count gate
-	// (would have failed under the old 451 requirement) and reach sig verification.
-	votes := buildAlignedVotes(300, [32]byte{})
-
-	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
-	require.Error(t, err)
-	require.NotContains(t, err.Error(), "not enough aligned votes")
-	require.Contains(t, err.Error(), "verifying tick signature")
+	require.ErrorContains(t, err, "not enough aligned votes [225]")
+	require.ErrorContains(t, err, "required [226]")
 }
 
 func TestValidateVotes_NonEmptyTick_StillRequiresFullQuorum(t *testing.T) {

--- a/validator/quorum/validator_test.go
+++ b/validator/quorum/validator_test.go
@@ -257,6 +257,87 @@ func deepCopy(votes types.QuorumVotes) types.QuorumVotes {
 	return cp
 }
 
+// buildAlignedVotes returns count votes that share every alignment-relevant field
+// (so getAlignedVotes returns all of them as one bucket). ComputorIndex differs per vote
+// but is not part of the alignment digest, so it does not affect bucketing.
+func buildAlignedVotes(count int, txDigest [32]byte) types.QuorumVotes {
+	votes := make(types.QuorumVotes, count)
+	for i := 0; i < count; i++ {
+		votes[i] = types.QuorumTickVote{
+			ComputorIndex:                 uint16(i),
+			Epoch:                         1,
+			Tick:                          100,
+			Millisecond:                   500,
+			Second:                        30,
+			Minute:                        15,
+			Hour:                          12,
+			Day:                           28,
+			Month:                         2,
+			Year:                          20,
+			PreviousResourceTestingDigest: 1234567890,
+			PreviousSpectrumDigest:        nonEmptyDigest(1),
+			PreviousUniverseDigest:        nonEmptyDigest(2),
+			PreviousComputerDigest:        nonEmptyDigest(3),
+			TxDigest:                      txDigest,
+		}
+	}
+	return votes
+}
+
+func TestValidateVotes_BelowFloor(t *testing.T) {
+	// 225 votes is below the 226-vote floor and must be rejected before alignment runs.
+	votes := buildAlignedVotes(EmptyTickMinVoteCount-1, [32]byte{})
+
+	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
+	require.ErrorContains(t, err, "not enough quorum votes")
+}
+
+func TestValidateVotes_EmptyTick_PassesCountGateAtFloor(t *testing.T) {
+	// Exactly 226 aligned empty-tick votes must clear both the floor and the post-alignment
+	// count check. Sig verification then fails (zero pubkeys/signatures), which is what we
+	// assert on to prove the count gates were passed.
+	votes := buildAlignedVotes(EmptyTickMinVoteCount, [32]byte{})
+
+	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "not enough quorum votes")
+	require.NotContains(t, err.Error(), "not enough aligned votes")
+	require.Contains(t, err.Error(), "verifying tick signature")
+}
+
+func TestValidateVotes_EmptyTick_PassesCountGateBetweenThresholds(t *testing.T) {
+	// 300 aligned empty-tick votes — the previously broken case. Must pass the count gate
+	// (would have failed under the old 451 requirement) and reach sig verification.
+	votes := buildAlignedVotes(300, [32]byte{})
+
+	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "not enough aligned votes")
+	require.Contains(t, err.Error(), "verifying tick signature")
+}
+
+func TestValidateVotes_NonEmptyTick_StillRequiresFullQuorum(t *testing.T) {
+	// 300 aligned votes for a non-empty tick must still be rejected at the count gate;
+	// the relaxed empty-tick threshold must not bleed into the non-empty path.
+	votes := buildAlignedVotes(300, nonEmptyDigest(7))
+
+	_, err := validateVotes(context.Background(), votes, computors.Computors{}, 0)
+	require.ErrorContains(t, err, "not enough aligned votes [300]")
+	require.ErrorContains(t, err, "required [451]")
+}
+
+func TestIsEmptyTick(t *testing.T) {
+	t.Run("zero TxDigest returns true", func(t *testing.T) {
+		require.True(t, IsEmptyTick(types.QuorumVotes{{TxDigest: [32]byte{}}}))
+	})
+	t.Run("non-zero TxDigest returns false", func(t *testing.T) {
+		require.False(t, IsEmptyTick(types.QuorumVotes{{TxDigest: nonEmptyDigest(1)}}))
+	})
+	t.Run("empty slice panics", func(t *testing.T) {
+		require.Panics(t, func() { IsEmptyTick(types.QuorumVotes{}) })
+	})
+}
+
 func TestByteSwap(t *testing.T) {
 
 	testData := []struct {

--- a/validator/validator.go
+++ b/validator/validator.go
@@ -51,7 +51,7 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 		if len(quorumVotes) <= 0 {
 			return errors.New("no quorum votes fetched")
 		}
-		if len(quorumVotes) < 451 {
+		if len(quorumVotes) < quorum.EmptyTickMinVoteCount {
 			return fmt.Errorf("not enough quorum votes yet: [%d]", len(quorumVotes))
 		}
 		return nil
@@ -122,7 +122,7 @@ func (v *Validator) Validate(ctx context.Context, store *db.PebbleStore, clients
 
 func (v *Validator) validateTickDataAndTransactions(ctx context.Context, alignedVotes types.QuorumVotes, clients Clients, comps computors.Computors, tickNumber uint32) (tickData types.TickData, validTxs []types.Transaction, txStatus *protobuf.TickTransactionsStatus, err error) {
 
-	if isEmptyTick(alignedVotes) {
+	if quorum.IsEmptyTick(alignedVotes) {
 		return types.TickData{}, make([]types.Transaction, 0), &protobuf.TickTransactionsStatus{}, nil
 	}
 
@@ -246,8 +246,4 @@ func getTxStatus(ctx context.Context, client network.QubicClient, transactionsCo
 			TransactionDigests: nil,
 		}, nil
 	}
-}
-
-func isEmptyTick(quorumVotes types.QuorumVotes) bool {
-	return quorumVotes[0].TxDigest == [32]byte{}
 }


### PR DESCRIPTION
Fixes #23.
The minimum required amount of aligned votes for a an empty tick is 226 and 451 for non empty.
Adds handling for case where tick is empty and aligned votes count is >=226. 