### PR TITLE
Release client on every error

### DIFF
--- a/processor/processor.go
+++ b/processor/processor.go
@@ -114,13 +114,17 @@ func (p *Processor) processOneByOne() error {
 	log.Printf("Next tick to process: [%d]. Current tick: [%d]. Delta [%d]", nextTick.TickNumber, tickInfo.Tick, int64(tickInfo.Tick)-int64(nextTick.TickNumber))
 
 	if nextTick.TickNumber > tickInfo.Tick {
-		return fmt.Errorf("next tick is in the future. processed: %d, next %d, available %d",
+		// set error for releasing client
+		err = fmt.Errorf("next tick is in the future. processed: %d, next %d, available %d",
 			lastProcessedTick.TickNumber, nextTick.TickNumber, tickInfo.Tick)
+		return err
 	}
 
 	// not sure if this helps because we will often be aligned at time of processing
 	if nextTick.TickNumber == tickInfo.Tick && tickInfo.NumberOfAlignedVotes < 451 {
-		return fmt.Errorf("tick not ready ([%d] aligned votes)", tickInfo.NumberOfAlignedVotes)
+		// set error for releasing client
+		err = fmt.Errorf("tick not ready ([%d] aligned votes)", tickInfo.NumberOfAlignedVotes)
+		return err
 	}
 
 	clients := validator.Clients{Main: client, Alt: alternativeClient}

--- a/processor/processor_test.go
+++ b/processor/processor_test.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"errors"
 	"log"
 	"testing"
 	"time"
@@ -38,6 +39,32 @@ type TestValidator struct{}
 
 func (t TestValidator) Validate(_ context.Context, _ *db.PebbleStore, _ validator.Clients, epoch uint16, tickNumber uint32) error {
 	log.Printf("Mock validated tick [%d] in epoch [%d].", tickNumber, epoch)
+	return nil
+}
+
+type FailingValidator struct{}
+
+func (f FailingValidator) Validate(_ context.Context, _ *db.PebbleStore, _ validator.Clients, _ uint16, _ uint32) error {
+	return errors.New("validation failed")
+}
+
+type TrackingPool struct {
+	client      network.QubicClient
+	putCalled   int
+	closeCalled int
+}
+
+func (t *TrackingPool) Get() (network.QubicClient, error) {
+	return t.client, nil
+}
+
+func (t *TrackingPool) Put(_ network.QubicClient) error {
+	t.putCalled++
+	return nil
+}
+
+func (t *TrackingPool) Close(_ network.QubicClient) error {
+	t.closeCalled++
 	return nil
 }
 
@@ -198,4 +225,23 @@ func TestProcessor_processOneByOne_epochChange(t *testing.T) {
 	require.NoError(t, err)
 	_, err = dataPool.GetDbForEpoch(43) // new epoch
 	require.NoError(t, err)
+}
+
+func TestProcessor_processOneByOne_clientClosedOnError(t *testing.T) {
+	client := &TestClient{
+		epoch:       42,
+		tick:        101,
+		InitialTick: 100,
+	}
+	pool := &TrackingPool{client: client}
+	testDir := t.TempDir()
+	dataPool, err := db.NewDatabasePool(testDir, 5)
+	require.NoError(t, err)
+
+	processor := NewProcessor(pool, dataPool, FailingValidator{}, Config{time.Second}, dummyMetrics)
+	err = processor.processOneByOne()
+	require.Error(t, err)
+
+	require.Equal(t, 2, pool.closeCalled, "both clients should be closed on error")
+	require.Equal(t, 0, pool.putCalled, "no clients should be returned to pool on error")
 }


### PR DESCRIPTION
* Previously the client did not get released when checking the tick number as the error object was not changed and the archiver was stuck on the hanging node until a call errored.